### PR TITLE
fix: update CRIU mentor and contact information

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -591,8 +591,35 @@
         "label": "CRIU Gitter"
       }
     ],
-    "mentors": [],
-    "mailingLists": [],
+    "mentors": [
+      {
+        "name": "Adrian Reber",
+        "github": "adrianreber",
+        "githubUrl": "https://github.com/adrianreber"
+      },
+      {
+        "name": "Radostin Stoyanov",
+        "github": "rst0git",
+        "githubUrl": "https://github.com/rst0git"
+      },
+      {
+        "name": "Pavel Tikhomirov",
+        "github": "Snorch",
+        "githubUrl": "https://github.com/Snorch"
+      },
+      {
+        "name": "Alexander Mikhalitsyn",
+        "github": "mihalicyn",
+        "githubUrl": "https://github.com/mihalicyn"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing List",
+        "url": "mailto:criu@openvz.org",
+        "label": "criu@openvz.org"
+      }
+    ],
     "tip": "Clone and build CRIU locally, and run a simple checkpoint/restore test before reaching out.",
     "status": "ok",
     "lastFetched": "2026-05-14T20:00:00.000Z"

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -584,12 +584,18 @@
   "CRIU": {
     "org": "CRIU",
     "ideasUrl": "https://github.com/checkpoint-restore/criu/wiki/GSoC-2026",
-    "channels": [],
+    "channels": [
+      {
+        "type": "Gitter",
+        "url": "https://gitter.im/checkpoint-restore/criu",
+        "label": "CRIU Gitter"
+      }
+    ],
     "mentors": [],
     "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "tip": "Clone and build CRIU locally, and run a simple checkpoint/restore test before reaching out.",
+    "status": "ok",
+    "lastFetched": "2026-05-14T20:00:00.000Z"
   },
   "Cuneiform Digital Library Initiative (CDLI)": {
     "org": "Cuneiform Digital Library Initiative (CDLI)",


### PR DESCRIPTION
## 🚀 Program
GSSoC

## 📝 Description
This PR updates the mentor and contact information for **CRIU**. 

The previous data was marked as `no-contact-found`. I have manually researched the official CRIU GSoC recommendations and updated the JSON entry.

- Changed `"status"` to `"ok"`.
- Added the official CRIU Gitter channel.
- Added a helpful tip about compiling the project and testing checkpoint/restore before applying.

All data was verified against the official CRIU website.

## 🔗 Related Issue
Closes #276

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI/configuration
- [ ] 🧹 Refactor/cleanup

## 🧪 How to Test
1. Check `data/mentors.json` for CRIU.
2. Verify `status` is `ok` and contact channels are present.


## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
