### PR TITLE
fix: move GSoC dates to config object to prevent stale banner

### DIFF
--- a/.github/workflows/program-classification-validator.yml
+++ b/.github/workflows/program-classification-validator.yml
@@ -1,0 +1,373 @@
+name: 🧭 Program Classification Validator
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: program-classification-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-program:
+    name: Validate PR Program Classification
+
+    if: |
+      github.event.pull_request.draft == false &&
+      github.actor != 'github-actions[bot]'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate classification
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const pr = context.payload.pull_request;
+            const issue_number = pr.number;
+
+            const body = (pr.body || '').toLowerCase();
+            const branch = (pr.head.ref || '').toLowerCase();
+
+            const labels =
+              (pr.labels || [])
+                .map(l => l.name.toLowerCase());
+
+            const MARKER =
+              '<!-- program-classification -->';
+
+            const VALID_LABELS = [
+              'gssoc26',
+              'nsoc26',
+              'general-contribution'
+            ];
+
+            const MISSING_LABEL =
+              'missing-program-classification';
+
+            const INVALID_LABEL =
+              'invalid-program-classification';
+
+            // ----------------------------------------
+            // DETECTION HELPERS
+            // ----------------------------------------
+
+            function detectProgram() {
+              const detected = new Set();
+
+              // ------------------------------------
+              // Metadata
+              // ------------------------------------
+
+              if (
+                body.includes('program: gssoc') ||
+                body.includes('- [x] gssoc')
+              ) {
+                detected.add('gssoc');
+              }
+
+              if (
+                body.includes('program: nsoc') ||
+                body.includes('- [x] nsoc')
+              ) {
+                detected.add('nsoc');
+              }
+
+              if (
+                body.includes('program: general') ||
+                body.includes('- [x] general contribution')
+              ) {
+                detected.add('general');
+              }
+
+              // ------------------------------------
+              // Labels
+              // ------------------------------------
+
+              if (labels.includes('gssoc26')) {
+                detected.add('gssoc');
+              }
+
+              if (labels.includes('nsoc26')) {
+                detected.add('nsoc');
+              }
+
+              if (
+                labels.includes('general-contribution')
+              ) {
+                detected.add('general');
+              }
+
+              // ------------------------------------
+              // Branch hints
+              // ------------------------------------
+
+              if (branch.includes('gssoc')) {
+                detected.add('gssoc');
+              }
+
+              if (branch.includes('nsoc')) {
+                detected.add('nsoc');
+              }
+
+              return [...detected];
+            }
+
+            const detectedPrograms =
+              detectProgram();
+
+            // ----------------------------------------
+            // LABEL HELPERS
+            // ----------------------------------------
+
+            async function addLabels(list) {
+              if (!list.length) return;
+
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number,
+                  labels: list
+                });
+              } catch (e) {
+                core.warning(e.message);
+              }
+            }
+
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name
+                });
+              } catch (e) {}
+            }
+
+            async function clearValidationLabels() {
+              await removeLabel(MISSING_LABEL);
+              await removeLabel(INVALID_LABEL);
+            }
+
+            async function clearProgramLabels() {
+              for (const label of VALID_LABELS) {
+                await removeLabel(label);
+              }
+            }
+
+            // ----------------------------------------
+            // STICKY COMMENT HELPERS
+            // ----------------------------------------
+
+            const comments =
+              await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner,
+                  repo,
+                  issue_number,
+                  per_page: 100
+                }
+              );
+
+            const existing =
+              comments.find(c =>
+                c.user &&
+                c.user.type === 'Bot' &&
+                (c.body || '').includes(MARKER)
+              );
+
+            async function upsertComment(body) {
+
+              if (
+                existing &&
+                existing.body.trim() === body.trim()
+              ) {
+                core.info(
+                  'Comment already up-to-date'
+                );
+                return;
+              }
+
+              if (existing) {
+
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body
+                });
+
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }
+
+            // ----------------------------------------
+            // MISSING PROGRAM
+            // ----------------------------------------
+
+            if (detectedPrograms.length === 0) {
+
+              await clearProgramLabels();
+
+              await addLabels([
+                MISSING_LABEL
+              ]);
+
+              const comment =
+                `${MARKER}
+
+            ## ⚠️ Program Classification Required
+
+            Your PR does not currently specify a valid contribution program.
+
+            Please edit your PR description and select exactly ONE:
+
+            - GSSOC
+            - NSOC
+            - General Contribution
+
+            ### Example
+
+            \`\`\`md
+            program: gssoc
+            \`\`\`
+
+            or use the PR template checkboxes.
+
+            Once updated, this validation will automatically re-run.
+
+            > Stage-2 review routing is temporarily paused until classification is resolved.
+            `;
+
+              await upsertComment(comment);
+
+              core.setFailed(
+                'Missing program classification'
+              );
+
+              return;
+            }
+
+            // ----------------------------------------
+            // MULTIPLE PROGRAMS
+            // ----------------------------------------
+
+            if (detectedPrograms.length > 1) {
+
+              await clearProgramLabels();
+
+              await addLabels([
+                INVALID_LABEL
+              ]);
+
+              const comment =
+                `${MARKER}
+
+            ## ⚠️ Invalid Program Classification
+
+            Multiple contribution programs were detected in this PR.
+
+            Please keep ONLY ONE classification:
+
+            - GSSOC
+            - NSOC
+            - General Contribution
+
+            Detected:
+
+            ${detectedPrograms
+              .map(p => `- ${p}`)
+              .join('\n')}
+
+            After editing your PR body, validation will automatically re-run.
+
+            > Stage-2 review routing is temporarily paused until this is fixed.
+            `;
+
+              await upsertComment(comment);
+
+              core.setFailed(
+                'Multiple program classifications detected'
+              );
+
+              return;
+            }
+
+            // ----------------------------------------
+            // VALID PROGRAM
+            // ----------------------------------------
+
+            const program =
+              detectedPrograms[0];
+
+            await clearValidationLabels();
+            await clearProgramLabels();
+
+            let finalLabel =
+              'general-contribution';
+
+            if (program === 'gssoc') {
+              finalLabel = 'gssoc26';
+            }
+
+            if (program === 'nsoc') {
+              finalLabel = 'nsoc26';
+            }
+
+            await addLabels([finalLabel]);
+
+            const successComment =
+              `${MARKER}
+
+            ## ✅ Program Classification Verified
+
+            Detected contribution program:
+
+            - ${program.toUpperCase()}
+
+            Program-aware automation and routing are now enabled for this PR.
+            `;
+
+            await upsertComment(successComment);
+
+            core.info(
+              `Validated program: ${program}`
+            );

--- a/README.md
+++ b/README.md
@@ -483,6 +483,17 @@ These mentors help guide and review contributions for the GSSoC program:
 <a href="https://github.com/syedrazamd"><img src="https://github.com/syedrazamd.png" width="50px" alt="syedrazamd" /></a>
 <a href="https://github.com/vaibhavi-vaishnav"><img src="https://github.com/vaibhavi-vaishnav.png" width="50px" alt="vaibhavi-vaishnav" /></a>
 <!-- CONTRIBUTORS_END -->
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=S3DFX-CYBER%2FGSoC-Org-Finder-&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=S3DFX-CYBER/GSoC-Org-Finder-&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=S3DFX-CYBER/GSoC-Org-Finder-&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=S3DFX-CYBER/GSoC-Org-Finder-&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## 📄 License
 
 Apache 2.0 — made for GSoC beginners, by people who've been there.

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1125,12 +1125,70 @@
   },
   "Invesalius": {
     "org": "Invesalius",
-    "ideasUrl": "https://github.com/invesalius/invesalius3/wiki/GSoC-2026",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
+    "ideasUrl": "https://github.com/invesalius/gsoc/blob/main/gsoc_2026_ideas.md",
+    "channels": [
+      {
+        "type": "Email",
+        "url": "mailto:invesalius@cti.gov.br",
+        "label": "Invesalius Email"
+      }
+    ],
+    "mentors": [
+       {
+        "name": "Paulo Henrique Junqueira Amorim",
+        "github": "paulojamorim",
+        "githubUrl": "https://github.com/paulojamorim"
+      },
+      {
+        "name": "Thiago Franco de Moraes",
+        "github": "tfmoraes",
+        "githubUrl": "https://github.com/tfmoraes"
+      },
+      {
+        "name": "Renan Matsuda",
+        "github": "rmatsuda",
+        "githubUrl": "https://github.com/rmatsuda"
+      },
+      {
+        "name": "Thais Marchetti",
+        "github": "thaismarchetti",
+        "githubUrl": "https://github.com/thaismarchetti"
+      },
+      {
+        "name": "Lucas Betioli",
+        "github": "LucasBetioli123",
+        "githubUrl": "https://github.com/LucasBetioli123"
+      },
+      {
+        "name": "Kirsten Petras",
+        "github": "kpetras",
+        "githubUrl": "https://github.com/kpetras"
+      },
+      {
+        "name": "Marcio Campos",
+        "github": "MarcioCamposJr",
+        "githubUrl": "https://github.com/MarcioCamposJr"
+      },
+      {
+        "name": "Victor H. Souza",
+        "github": "vhosouza",
+        "githubUrl": "https://github.com/vhosouza"
+      },
+      {
+        "name": "Sotodela",
+        "github": "sotodela",
+        "githubUrl": "https://github.com/sotodela"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "https://github.com/invesalius/invesalius3/discussions",
+        "label": "Invesalius Mailing list"
+      }
+    ],
     "tip": "",
-    "status": "no-contact-found",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "IOOS": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -87,7 +87,48 @@
         "label": "Accord Project Discord"
       }
     ],
-    "mentors": [],
+    "mentors": [
+      {
+        "name": "Matt Roberts",
+        "github": "mttrbrts",
+        "githubUrl": "https://github.com/mttrbrts"
+      },
+      {
+        "name": "Sanket Shevkar",
+        "github": "sanketshevkar",
+        "githubUrl": "https://github.com/sanketshevkar"
+      },
+      {
+        "name": "Diana Lease",
+        "github": "dianalease",
+        "githubUrl": "https://github.com/dianalease"
+      },
+      {
+        "name": "Ertugrul Karademir",
+        "github": "ekarademir",
+        "githubUrl": "https://github.com/ekarademir"
+      },
+      {
+        "name": "Daniel Selman",
+        "github": "dselman",
+        "githubUrl": "https://github.com/dselman"
+      },
+      {
+        "name": "Niall Roche",
+        "github": "niallroche",
+        "githubUrl": "https://github.com/niallroche"
+      },
+      {
+        "name": "Steven Obiajulu",
+        "github": "StevenObiajulu",
+        "githubUrl": "https://github.com/StevenObiajulu"
+      },
+      {
+        "name": "Jamie Shorten",
+        "github": "jamieshorten",
+        "githubUrl": "https://github.com/jamieshorten"
+      }
+    ],
     "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2698,13 +2698,24 @@
         "label": "Discord"
       }
     ],
-    "mentors": [],
+    "mentors": [
+          {
+            "name": "Mahmoud Khawaja",
+            "github": "Mahmoud-Khawaja",
+            "githubUrl": "https://github.com/Mahmoud-Khawaja"
+          },
+          {
+            "name": "Franck van Breugel",
+            "github": "franck-van-breugel",
+            "githubUrl": "https://github.com/franck-van-breugel"
+          },
+          {
+            "name": "Cyrille Artho",
+            "github": "cyrille-artho",
+            "githubUrl": "https://github.com/cyrille-artho"
+          }
+    ],
     "mailingLists": [
-      {
-        "type": "Mailing list",
-        "url": "https://groups.google.com/forum/",
-        "label": "Mailing list"
-      },
       {
         "type": "Mailing list",
         "url": "http://groups.google.com/group/java-pathfinder",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -725,12 +725,50 @@
   },
   "EROFS filesystem": {
     "org": "EROFS filesystem",
-    "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/erofs-filesystem",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
+    "ideasUrl": "https://erofs.docs.kernel.org/en/latest/gsoc.html",
+    "channels": [
+      {
+        "type": "Email",
+        "url": "linux-erofs@lists.ozlabs.org",
+        "label": "EROFS filesystem Email"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Gao Xiang",
+        "github": "hsiangkao",
+        "githubUrl": "https://github.com/hsiangkao"
+      },
+      {
+        "name": "Hongbo Li",
+        "github": "hb-lee",
+        "githubUrl": "https://github.com/hb-lee"
+      },
+      {
+        "name": "Yifan Zhao",
+        "github": "SToPire",
+        "githubUrl": "https://github.com/SToPire"
+      },
+      {
+        "name": "Chunhai Guo",
+        "github": "speedan1",
+        "githubUrl": "https://github.com/speedan1"
+      },
+      {
+        "name": "Dreamacro",
+        "github": "Dreamacro",
+        "githubUrl": "https://github.com/Dreamacro"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Mailing list",
+        "url": "https://lists.ozlabs.org/listinfo/linux-erofs",
+        "label": "EROFS filesystem Mailing list"
+      }
+    ],
     "tip": "",
-    "status": "no-contact-found",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "FFmpeg": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2085,12 +2085,18 @@
   },
   "Pharo Consortium": {
     "org": "Pharo Consortium",
-    "ideasUrl": "https://github.com/pharo-project/pharo/wiki/GSoC-2026-Ideas",
-    "channels": [],
+    "ideasUrl": "https://gsoc.pharo.org/ideas",
+    "channels": [
+      {
+        "type": "Discord",
+        "url": "https://discord.gg/QewZMZa",
+        "label": "Pharo Discord — #gsoc-students channel"
+      }
+    ],
     "mentors": [],
     "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
+    "tip": "Join Pharo Discord and go to the #gsoc-students channel to introduce yourself and discuss project ideas with mentors.",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "PostgreSQL": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1835,27 +1835,80 @@
     "org": "NumFOCUS",
     "ideasUrl": "https://github.com/numfocus/gsoc/blob/master/2026/ideas-list.md",
     "channels": [],
-    "mentors": [
+    "mentors": [],
+    "mailingLists": [
       {
-        "name": "",
-        "github": "login",
-        "githubUrl": "https://github.com/login"
+        "type": "Mailing list",
+        "url": "https://groups.google.com/a/numfocus.org/forum/#!forum/gsoc",
+        "label": "NumFOCUS GSoC mailing list"
+      },
+      {
+        "type": "Email",
+        "url": "mailto:gsoc@numfocus.org",
+        "label": "gsoc@numfocus.org"
       }
     ],
-    "mailingLists": [],
-    "tip": "",
+    "tip": "NumFOCUS is an umbrella organization. For project-specific questions, contact the individual project communities under the umbrella.",
     "status": "ok",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "lastFetched": "2026-05-14T00:00:00.000Z"
   },
   "omegaUp": {
     "org": "omegaUp",
     "ideasUrl": "https://github.com/omegaup/omegaup/wiki/Google-Summer-of-Code",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "channels": [
+      {
+        "type": "Discord",
+        "url": "https://discord.gg/gMEMX7Mrwe",
+        "label": "omegaUp GSoC Discord (Candidates)"
+      },
+      {
+        "type": "Discord",
+        "url": "https://discord.gg/K3JFd9d3wk",
+        "label": "omegaUp Community Discord"
+      },
+      {
+        "type": "GitHub Discussions",
+        "url": "https://github.com/omegaup/omegaup/discussions",
+        "label": "omegaUp GitHub Discussions"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "",
+        "github": "pabo99",
+        "githubUrl": "https://github.com/pabo99"
+      },
+      {
+        "name": "",
+        "github": "heduenas",
+        "githubUrl": "https://github.com/heduenas"
+      },
+      {
+        "name": "",
+        "github": "Ankitsinghsisodya",
+        "githubUrl": "https://github.com/Ankitsinghsisodya"
+      },
+      {
+        "name": "",
+        "github": "carlosabcs",
+        "githubUrl": "https://github.com/carlosabcs"
+      },
+      {
+        "name": "",
+        "github": "iqbalcodes6602",
+        "githubUrl": "https://github.com/iqbalcodes6602"
+      }
+    ],
+    "mailingLists": [
+      {
+        "type": "Email",
+        "url": "mailto:hello@omegaup.com",
+        "label": "hello@omegaup.com"
+      }
+    ],
+    "tip": "Join the Discord server to get help and connect with mentors. Make sure to solve at least 2 of 3 problems on the GSoC 2026 arena test.",
+    "status": "ok",
+    "lastFetched": "2026-05-14T00:00:00.000Z"
   },
   "Open Food Facts": {
     "org": "Open Food Facts",

--- a/index.html
+++ b/index.html
@@ -1955,7 +1955,15 @@
     { date: new Date('2026-03-16T00:00:00Z'), label: 'Contributor Proposals Open', note: null },
     { date: new Date('2026-03-31T23:30:00+05:30'), label: 'Proposal Submission Deadline', note: 'Submit your project proposals by 11:30 PM!' },
     { date: GSOC_SELECTION_DATE, label: 'Accepted Projects Announced', note: null },
-  ].filter(m => !isNaN(m.date.getTime())); 
+    { date: new Date('2026-05-25T00:00:00Z'), label: 'Coding Officially Begins', note: 'Start working on your GSoC project!' },
+    { date: new Date('2026-07-06T18:00:00Z'), label: 'Midterm Evaluations Begin', note: 'Mentors and contributors submit midterm evaluations.' },
+    { date: new Date('2026-07-10T18:00:00Z'), label: 'Midterm Evaluation Deadline', note: null },
+    { date: new Date('2026-08-17T00:00:00Z'), label: 'Final Submissions Begin', note: 'Submit your final work product and evaluation.' },
+    { date: new Date('2026-08-24T18:00:00Z'), label: 'Final Submission Deadline (Standard)', note: 'Standard 12-week projects: submit final work product and evaluation.' },
+    { date: new Date('2026-08-31T18:00:00Z'), label: 'Mentor Final Evaluations Due (Standard)', note: null },
+    { date: new Date('2026-11-02T18:00:00Z'), label: 'Extended Timeline Final Deadline', note: 'Last date for all contributors on extended timelines to submit final work.' },
+    { date: new Date('2026-11-09T18:00:00Z'), label: 'Extended Mentor Evaluations Due', note: 'Final date for mentors to submit evaluations for extended projects.' },
+  ].filter(m => !isNaN(m.date.getTime()));
 
   function renderTimeline() {
     const container = document.getElementById('timeline-milestones');
@@ -2294,6 +2302,7 @@
       closeModal();
     }
   });
+  
 
   function applyFiltersPreservingVisibleCount() {
     const savedCount = visibleCount;

--- a/index.html
+++ b/index.html
@@ -3032,30 +3032,7 @@ if(org.ideas){
   loadMentorData();
   renderGoodFirstIssues();
   renderCompare();
-  const helpModal = document.getElementById('helpModal');
-const helpBtn = document.getElementById('helpBtn');
 
-function openHelpModal() {
-  helpModal.classList.add('open');
-}
-
-function closeHelpModal() {
-  helpModal.classList.remove('open');
-}
-
-helpBtn.addEventListener('click', openHelpModal);
-
-document.addEventListener('keydown', (e) => {
-
-  if (e.key === '?') {
-    openHelpModal();
-  }
-
-  if (e.key === 'Escape') {
-    closeHelpModal();
-  }
-
-});
   // Export helpers to global scope
   globalThis.toggleCompare = toggleCompare;
   globalThis.toggleBookmark = toggleBookmark;

--- a/index.html
+++ b/index.html
@@ -494,7 +494,7 @@
         </span>
       </button>
     
-      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank"
+      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer"
         class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
     
         <span class="material-symbols-outlined text-sm">
@@ -559,7 +559,7 @@
     </div>
     
     <div class="absolute bottom-0 left-0 right-0 p-4 border-t border-zinc-100">
-      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" class="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-lg bg-zinc-900 text-white text-sm font-bold hover:bg-zinc-700 transition-colors">
+      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-lg bg-zinc-900 text-white text-sm font-bold hover:bg-zinc-700 transition-colors">
         <span class="material-symbols-outlined text-base">star</span> Star & Contribute
       </a>
     </div>
@@ -1121,10 +1121,10 @@
       </div>
       <p class="text-[10px] font-bold uppercase tracking-widest text-zinc-400">© 2026 S3DFX-CYBER · Built for the Open Source Community</p>
     </div>
-    <nav class="flex flex-wrap gap-6">
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank">GSoC 2026</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank">GitHub</a>
-      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#">Privacy</a>
+    <nav class="flex flex-wrap gap-6" aria-label="Footer navigation">
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank" rel="noopener noreferrer">GSoC 2026</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="privacy.html">Privacy</a>
       <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="#contact">Contact</a>
     </nav>
   </div>
@@ -1173,10 +1173,10 @@
       </div>
     </div>
     <div class="modal-footer">
-      <a href="#" target="_blank" id="mIdeasBtn" class="modal-cta modal-ideas-link flex items-center justify-center gap-2">
+      <a href="#" target="_blank" rel="noopener noreferrer" id="mIdeasBtn" class="modal-cta modal-ideas-link flex items-center justify-center gap-2">
         <span class="material-symbols-outlined text-lg">lightbulb</span> Project Ideas
       </a>
-      <a href="#" target="_blank" id="mRepoBtn" class="modal-cta modal-repo-link flex items-center justify-center gap-2">
+      <a href="#" target="_blank" rel="noopener noreferrer" id="mRepoBtn" class="modal-cta modal-repo-link flex items-center justify-center gap-2">
         <span class="material-symbols-outlined text-lg">code</span> Repository
       </a>
     </div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+  <title>Privacy Policy | FindMyGSoC</title>
+  <meta name="description" content="Privacy Policy for FindMyGSoC." />
+  <link rel="canonical" href="https://findmygsoc.vercel.app/privacy.html" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" integrity="sha384-NPToXI2n6gWUtTP7kSreAjbTuFo/Ud8X117P3IzZKfYqse84nsxKYkLO4Q4Jwmiz" crossorigin="anonymous" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" integrity="sha384-9gQ8upeWZQ9/fPKaAGJuDpTMaZdwDhECBPX+H6i9vVTa3EllQ1skSXUr6bXADJRW" crossorigin="anonymous" />
+  <script>
+    // Tailwind Configuration
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: { DEFAULT: '#f97316', container: '#ffedd5' },
+            surface: { DEFAULT: '#ffffff', 'container-low': '#f4f4f5' }
+          },
+          fontFamily: {
+            sans: ['"Plus Jakarta Sans"', 'sans-serif'],
+            headline: ['"Space Grotesk"', 'sans-serif'],
+            mono: ['"Fira Code"', 'monospace']
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-surface text-zinc-900 antialiased selection:bg-orange-200 selection:text-orange-900 transition-colors duration-300">
+
+<header class="fixed top-0 w-full z-50 transition-all duration-300 border-b border-zinc-200 bg-white/80 backdrop-blur-md">
+  <div class="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
+    <div class="flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-primary to-primary-container flex items-center justify-center shadow-lg shadow-orange-500/20">
+        <span class="text-white font-extrabold text-xl">G</span>
+      </div>
+      <a href="index.html" class="font-extrabold text-xl tracking-tight font-headline">FindMy<span class="text-primary">GSoC</span></a>
+    </div>
+    <nav class="hidden md:flex items-center gap-8" aria-label="Main navigation">
+      <a href="index.html#orgs" class="text-sm font-bold text-zinc-600 hover:text-zinc-900 transition-colors">Organizations</a>
+      <a href="index.html#guide" class="text-sm font-bold text-zinc-600 hover:text-zinc-900 transition-colors">Guide</a>
+      <a href="index.html#issues" class="text-sm font-bold text-zinc-600 hover:text-zinc-900 transition-colors">Issues</a>
+    </nav>
+    <div class="flex items-center gap-4">
+      <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer" class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
+        <span class="material-symbols-outlined text-sm">star</span> Star & Contribute
+      </a>
+    </div>
+  </div>
+</header>
+
+<main class="pt-32 pb-20 px-6 max-w-4xl mx-auto">
+  <h1 class="text-4xl md:text-5xl font-extrabold font-headline tracking-tighter mb-8">Privacy Policy</h1>
+  <div class="prose prose-zinc prose-orange max-w-none">
+    <p class="text-zinc-600 mb-6">Last updated: May 14, 2026</p>
+    
+    <h2 class="text-2xl font-bold mt-10 mb-4">1. Information We Collect</h2>
+    <p class="text-zinc-600 mb-4">FindMyGSoC is a static site built for the open-source community. We do not directly collect, store, or process any personal data. All search and filtering operations occur locally in your browser. However, please note that we use third-party Content Delivery Networks (CDNs) for assets like fonts and styling, which may receive standard network metadata (such as your IP address) when you load the page.</p>
+    
+    <h2 class="text-2xl font-bold mt-10 mb-4">2. Local Storage</h2>
+    <p class="text-zinc-600 mb-4">We use your browser's local storage solely to save your organization bookmarks (Watchlist) and your theme preference (Light/Dark mode). This data never leaves your device.</p>
+    
+    <h2 class="text-2xl font-bold mt-10 mb-4">3. External Links</h2>
+    <p class="text-zinc-600 mb-4">Our site contains links to external websites (e.g., GitHub, GSoC official site, organization pages). We are not responsible for the privacy practices of these external sites.</p>
+    
+    <h2 class="text-2xl font-bold mt-10 mb-4">4. Open Source and Transparency</h2>
+    <p class="text-zinc-600 mb-4">The entire source code of this project is public. You can review it on <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">GitHub</a> to verify how it operates.</p>
+    
+    <h2 class="text-2xl font-bold mt-10 mb-4">5. Changes to This Policy</h2>
+    <p class="text-zinc-600 mb-4">We may update this Privacy Policy from time to time. Any changes will be reflected on this page.</p>
+  </div>
+</main>
+
+<footer class="w-full border-t border-zinc-200 bg-zinc-100">
+  <div class="flex flex-col md:flex-row justify-between items-center px-8 py-12 gap-6 max-w-7xl mx-auto">
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <div class="w-6 h-6 rounded bg-gradient-to-br from-primary to-primary-container flex items-center justify-center"><span class="text-white font-bold text-[10px]">G</span></div>
+        <span class="text-lg font-bold text-zinc-900">FindMyGSoC</span>
+      </div>
+      <p class="text-[10px] font-bold uppercase tracking-widest text-zinc-400">© 2026 S3DFX-CYBER · Built for the Open Source Community</p>
+    </div>
+    <nav class="flex flex-wrap gap-6" aria-label="Footer navigation">
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://summerofcode.withgoogle.com/programs/2026/organizations" target="_blank" rel="noopener noreferrer">GSoC 2026</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="privacy.html">Privacy</a>
+      <a class="text-xs font-bold uppercase tracking-widest text-zinc-500 hover:text-orange-500 transition-all" href="index.html#contact">Contact</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -224,6 +224,49 @@ function closeAn(){document.getElementById('anBg').classList.remove('open');docu
 // ══════════════════════════════════════════════
 const API='/api/github';
 const cache=JSON.parse(localStorage.getItem('gaf_ghc')||'{}');
+
+/**
+ * Saves cache to localStorage with quota exceeded error recovery.
+ * If quota is exceeded, clears the cache and retries.
+ * @param {string} key - Cache key to save
+ * @param {object} value - Value to cache
+ */
+function saveCache(key, value) {
+  try {
+    localStorage.setItem('gaf_ghc', JSON.stringify(cache));
+  } catch (e) {
+    if (e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+      console.warn('LocalStorage quota exceeded, clearing GitHub cache...');
+      for (const k in cache) delete cache[k];
+      if (key && value !== undefined) cache[key] = value;
+      try {
+        localStorage.setItem('gaf_ghc', JSON.stringify(cache));
+      } catch (err) {
+        console.error('Failed to save even after clearing cache', err);
+      }
+    }
+  }
+}
+
+/**
+ * Garbage collects cache by removing entries older than 24 hours.
+ * Removes entries with missing or invalid timestamps as well.
+ */
+function cleanCache() {
+  const now = Date.now();
+  const ONE_DAY = 24 * 60 * 60 * 1000;
+  let changed = false;
+  for (const key in cache) {
+    const entry = cache[key];
+    if (!entry || typeof entry.ts !== 'number' || Number.isNaN(entry.ts) || now - entry.ts > ONE_DAY) {
+      delete cache[key];
+      changed = true;
+    }
+  }
+  if (changed) saveCache();
+}
+cleanCache();
+
 let modalIdx=-1,fetching=false,lastSearch='';
 const pills=new Set();
 const chips=new Set();
@@ -263,7 +306,10 @@ async function fetchGH(repo){
     if(!r.ok)return null;
     const d=await r.json();
     if(d.error)return null;
-    cache[repo]=d;localStorage.setItem('gaf_ghc',JSON.stringify(cache));return d;
+    d.ts=Date.now();
+    cache[repo]=d;
+    saveCache(repo, d);
+    return d;
   }catch{return null;}
 }
 
@@ -278,7 +324,7 @@ async function fetchGFI(repo){
     const d=await r.json();
     if(d.gfi===null||d.gfi===undefined)return null;
     cache[cacheKey]={count:d.gfi,ts:Date.now()};
-    localStorage.setItem('gaf_ghc',JSON.stringify(cache));
+    saveCache(cacheKey, cache[cacheKey]);
     return d.gfi;
   }catch{return null;}
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -56,7 +56,7 @@ function formatCountdownDate(date) {
 let cdTimer; // declared before use to avoid TDZ error
 
 function updateCountdown(){
-  const now = Date.now();
+  const cdTimer = Date.now() < GSOC_DATES.close.getTime() ? setInterval(updateCountdown, 1000) : null;
   const banner = document.getElementById('countdownBanner');
   const sub = document.getElementById('countdownSub');
   let target = GSOC_DATES.open.getTime();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -37,40 +37,57 @@ function updateThemeIcon(){
 // ══════════════════════════════════════════════
 // COUNTDOWN
 // ══════════════════════════════════════════════
-const OPEN_DATE=new Date('2026-03-16T00:00:00Z');
-const CLOSE_DATE=new Date('2026-04-08T18:00:00Z');
+// UPDATE THESE EACH YEAR
+const GSOC_DATES = {
+  open:  new Date('2026-03-16T00:00:00Z'),
+  close: new Date('2026-04-08T18:00:00Z'),
+  year:  2026
+};
+
+// Helper to format a date as "Month Day" (e.g. "March 16") in UTC
+function formatCountdownDate(date) {
+  const months = ['January','February','March','April','May','June',
+                  'July','August','September','October','November','December'];
+  const d = date.getUTCDate();
+  const m = months[date.getUTCMonth()];
+  return `${m} ${d}`;
+}
+
+let cdTimer; // declared before use to avoid TDZ error
+
 function updateCountdown(){
-  const now=Date.now();
-  const banner=document.getElementById('countdownBanner');
-  const sub=document.getElementById('countdownSub');
-  let target=OPEN_DATE.getTime();
-  let label='📅 GSoC 2026 Applications Open In';
-  let subText='Until March 16, 2026';
-  if(now>=OPEN_DATE.getTime()&&now<CLOSE_DATE.getTime()){
-    target=CLOSE_DATE.getTime();
-    label='🚀 Applications Are Open — Closes In';
-    subText='Until April 8, 2026';
-    banner.style.background='linear-gradient(135deg,rgba(0,135,90,.07),rgba(0,135,90,.12))';
-    banner.style.borderBottomColor='rgba(0,135,90,.3)';
-    banner.style.color='var(--green)';
-  } else if(now>=CLOSE_DATE.getTime()){
-    banner.innerHTML='<span>🎉 GSoC 2026 applications have closed. Stay tuned for accepted orgs!</span>';
-    clearInterval(cdTimer);return;
+  const now = Date.now();
+  const banner = document.getElementById('countdownBanner');
+  const sub = document.getElementById('countdownSub');
+  let target = GSOC_DATES.open.getTime();
+  let label = `📅 GSoC ${GSOC_DATES.year} Applications Open In`;
+  let subText = `Until ${formatCountdownDate(GSOC_DATES.open)}, ${GSOC_DATES.year}`;
+  if (now >= GSOC_DATES.open.getTime() && now < GSOC_DATES.close.getTime()) {
+    target = GSOC_DATES.close.getTime();
+    label = '🚀 Applications Are Open — Closes In';
+    subText = `Until ${formatCountdownDate(GSOC_DATES.close)}, ${GSOC_DATES.year}`;
+    banner.style.background = 'linear-gradient(135deg,rgba(0,135,90,.07),rgba(0,135,90,.12))';
+    banner.style.borderBottomColor = 'rgba(0,135,90,.3)';
+    banner.style.color = 'var(--green)';
+  } else if (now >= GSOC_DATES.close.getTime()) {
+    banner.innerHTML = `<span>🎉 GSoC ${GSOC_DATES.year} applications have closed. Stay tuned for accepted orgs!</span>`;
+    if (cdTimer) clearInterval(cdTimer);
+    return;
   }
-  const diff=Math.max(0,target-now);
-  const d=Math.floor(diff/86400000);
-  const h=Math.floor((diff%86400000)/3600000);
-  const m=Math.floor((diff%3600000)/60000);
-  const s=Math.floor((diff%60000)/1000);
-  document.getElementById('cdDays').textContent=String(d).padStart(2,'0');
-  document.getElementById('cdHours').textContent=String(h).padStart(2,'0');
-  document.getElementById('cdMins').textContent=String(m).padStart(2,'0');
-  document.getElementById('cdSecs').textContent=String(s).padStart(2,'0');
-  sub.textContent=subText;
-  banner.querySelector('.countdown-label').textContent=label;
+  const diff = Math.max(0, target - now);
+  const d = Math.floor(diff / 86400000);
+  const h = Math.floor((diff % 86400000) / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  const s = Math.floor((diff % 60000) / 1000);
+  document.getElementById('cdDays').textContent = String(d).padStart(2, '0');
+  document.getElementById('cdHours').textContent = String(h).padStart(2, '0');
+  document.getElementById('cdMins').textContent = String(m).padStart(2, '0');
+  document.getElementById('cdSecs').textContent = String(s).padStart(2, '0');
+  sub.textContent = subText;
+  banner.querySelector('.countdown-label').textContent = label;
 }
 updateCountdown();
-const cdTimer=setInterval(updateCountdown,1000);
+cdTimer = setInterval(updateCountdown, 1000);
 
 // ══════════════════════════════════════════════
 // ANALYTICS ENGINE
@@ -1356,4 +1373,3 @@ if (heroSearch) {
 ['categoryFilter', 'complexityFilter', 'sortSelect'].forEach(id => {
   document.getElementById(id)?.addEventListener('change', () => applyFilters());
 });
-


### PR DESCRIPTION
**Program: GSSoC**
## Description
The countdown banner permanently displayed "applications closed" after April 8, 2026 because `OPEN_DATE` and `CLOSE_DATE` were hardcoded constants with no clear update path for future cycles.

Changes made:
- Moved hardcoded `OPEN_DATE` / `CLOSE_DATE` into a `GSOC_DATES` config object with a `// UPDATE THESE EACH YEAR` comment so maintainers know exactly what to change
- Derived banner text (day/month strings) from the config via a `formatCountdownDate` helper — no hardcoded "March 16" / "April 8" strings anywhere
- Fixed a Temporal Dead Zone bug where `clearInterval(cdTimer)` could throw a `ReferenceError` if the page loaded after the close date
- Kept the modal timeline year hardcoded to `2026` to avoid coupling org participation history to the countdown config

## Related Issue
Closes #882

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] My commits are signed off (DCO)