### PR TITLE
feat: add a button of view more mentors same like view more organizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1287,7 +1287,7 @@
     </div>
 
     <div class="mt-12 flex justify-center" id="loadMoreMentorContainer" style="display:none">
-      <button type="button" id="loadMoreMentorBtn" aria-label="Load more mentors" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
+      <button type="button" id="loadMoreMentorBtn" aria-label="View More Mentors" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
         View More Mentors <span class="material-symbols-outlined text-lg">expand_more</span>
       </button>
     </div>

--- a/index.html
+++ b/index.html
@@ -1285,6 +1285,12 @@
         <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
       </div>
     </div>
+
+    <div class="mt-12 flex justify-center" id="loadMoreMentorContainer" style="display:none">
+      <button id="loadMoreMentorBtn" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
+        View More Mentors <span class="material-symbols-outlined text-lg">expand_more</span>
+      </button>
+    </div>
   </div>
 </section>
  
@@ -1894,6 +1900,7 @@
   // MAIN APP LOGIC
   // ══════════════════════════════════════════════
   let visibleCount = 12;
+  let visibleMentorCount = 12;
 
   let filteredOrgs = [...ORGS];
   let MENTOR_DATA = {};
@@ -2255,10 +2262,15 @@
     }));
   }
 
-  function renderMentorFinder() {
+  function renderMentorFinder(reset = true) {
     const grid = document.getElementById('mentorGrid');
     const lastUpdatedEl = document.getElementById('mentorLastUpdated');
     if (!grid) return;
+
+    if (reset) {
+      grid.innerHTML = '';
+      visibleMentorCount = 12;
+    }
 
     if (mentorDataState === 'loading' || mentorDataState === 'idle') {
       grid.innerHTML = `
@@ -2308,10 +2320,12 @@
           <p class="text-sm text-zinc-600">Try a different org name, GitHub handle, or channel filter.</p>
         </div>
       `;
+      document.getElementById('loadMoreMentorContainer').style.display = 'none';
       return;
     }
 
-    grid.innerHTML = filteredRecords.map(({ org, entry }) => {
+    const slice = filteredRecords.slice(visibleMentorCount - 12, visibleMentorCount);
+    grid.innerHTML = slice.map(({ org, entry }) => {
       const primary = getPrimaryMentorContact(entry);
       const mentorPreview = entry.mentors
         .slice(0, 3)
@@ -2377,6 +2391,11 @@
       `;
     }).join('');
 
+    if (visibleMentorCount < filteredRecords.length) {
+      document.getElementById('loadMoreMentorContainer').style.display = 'flex';
+    } else {
+      document.getElementById('loadMoreMentorContainer').style.display = 'none';
+    }
     attachOrgCardListeners(grid);
   }
 
@@ -3502,6 +3521,11 @@ if(org.ideas){
   document.getElementById('loadMoreBtn').addEventListener('click', () => {
     visibleCount += 12;
     renderOrgs(false);
+  });
+
+  document.getElementById('loadMoreMentorBtn').addEventListener('click', () => {
+    visibleMentorCount += 12;
+    renderMentorFinder(false);
   });
 
   // Surprise button event listener

--- a/index.html
+++ b/index.html
@@ -2325,7 +2325,7 @@
     }
 
     const slice = filteredRecords.slice(visibleMentorCount - 12, visibleMentorCount);
-    grid.innerHTML = slice.map(({ org, entry }) => {
+    slice.forEach(({ org, entry }) => {
       const primary = getPrimaryMentorContact(entry);
       const mentorPreview = entry.mentors
         .slice(0, 3)
@@ -2373,23 +2373,24 @@
       const contactHref = primary?.url || org.ideas || githubUrlFromValue(org.github);
       const safeContactHref = sanitizeHrefUrl(contactHref);
 
-      return `
-        <article class="mentor-card">
-          <div class="flex items-start justify-between gap-3 mb-4">
-            <div>
-              <p class="text-[10px] font-label uppercase tracking-widest text-primary mb-1">${escapeHtml(org.cat)}</p>
-              <h3 class="font-headline text-xl font-bold text-zinc-900">${escapeHtml(org.name)}</h3>
-            </div>
-            <span class="text-xs font-bold uppercase tracking-widest px-2 py-1 rounded-full ${statusClass}">${escapeHtml(entry.status)}</span>
+      const article = document.createElement('article');
+      article.className = 'mentor-card';
+      article.innerHTML = `
+        <div class="flex items-start justify-between gap-3 mb-4">
+          <div>
+            <p class="text-[10px] font-label uppercase tracking-widest text-primary mb-1">${escapeHtml(org.cat)}</p>
+            <h3 class="font-headline text-xl font-bold text-zinc-900">${escapeHtml(org.name)}</h3>
           </div>
-          ${bodyHtml}
-          <div class="mt-5 pt-4 border-t border-zinc-100">
-            ${safeContactHref ? `<a href="${escapeHtml(safeContactHref)}" target="_blank" rel="noopener noreferrer" class="mentor-link-chip"><span>📡</span><span>${escapeHtml(contactLabel)}</span></a>` : `<span class="mentor-link-chip"><span>📡</span><span>${escapeHtml(contactLabel)}</span></span>`}
-            <p class="text-xs text-zinc-500 mt-3">${helperText}</p>
-          </div>
-        </article>
+          <span class="text-xs font-bold uppercase tracking-widest px-2 py-1 rounded-full ${statusClass}">${escapeHtml(entry.status)}</span>
+        </div>
+        ${bodyHtml}
+        <div class="mt-5 pt-4 border-t border-zinc-100">
+          ${safeContactHref ? `<a href="${escapeHtml(safeContactHref)}" target="_blank" rel="noopener noreferrer" class="mentor-link-chip"><span>📡</span><span>${escapeHtml(contactLabel)}</span></a>` : `<span class="mentor-link-chip"><span>📡</span><span>${escapeHtml(contactLabel)}</span></span>`}
+          <p class="text-xs text-zinc-500 mt-3">${helperText}</p>
+        </div>
       `;
-    }).join('');
+      grid.appendChild(article);
+    });
 
     if (visibleMentorCount < filteredRecords.length) {
       document.getElementById('loadMoreMentorContainer').style.display = 'flex';

--- a/index.html
+++ b/index.html
@@ -1287,7 +1287,7 @@
     </div>
 
     <div class="mt-12 flex justify-center" id="loadMoreMentorContainer" style="display:none">
-      <button id="loadMoreMentorBtn" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
+      <button type="button" id="loadMoreMentorBtn" aria-label="Load more mentors" class="px-10 py-4 bg-primary text-white font-headline font-bold rounded-full text-sm hover:scale-[1.02] active:scale-[0.98] transition-all shadow-lg shadow-primary/20 flex items-center gap-2">
         View More Mentors <span class="material-symbols-outlined text-lg">expand_more</span>
       </button>
     </div>
@@ -2340,7 +2340,10 @@ sections.forEach(sectionId => {
           <p class="text-sm text-zinc-600">Try a different org name, GitHub handle, or channel filter.</p>
         </div>
       `;
-      document.getElementById('loadMoreMentorContainer').style.display = 'none';
+      const loadMoreContainer = document.getElementById('loadMoreMentorContainer');
+      if (loadMoreContainer) {
+        loadMoreContainer.style.display = 'none';
+      }
       return;
     }
 
@@ -2412,10 +2415,13 @@ sections.forEach(sectionId => {
       grid.appendChild(article);
     });
 
-    if (visibleMentorCount < filteredRecords.length) {
-      document.getElementById('loadMoreMentorContainer').style.display = 'flex';
-    } else {
-      document.getElementById('loadMoreMentorContainer').style.display = 'none';
+    const loadMoreContainer = document.getElementById('loadMoreMentorContainer');
+    if (loadMoreContainer) {
+      if (visibleMentorCount < filteredRecords.length) {
+        loadMoreContainer.style.display = 'flex';
+      } else {
+        loadMoreContainer.style.display = 'none';
+      }
     }
     attachOrgCardListeners(grid);
   }
@@ -3544,7 +3550,7 @@ if(org.ideas){
     renderOrgs(false);
   });
 
-  document.getElementById('loadMoreMentorBtn').addEventListener('click', () => {
+  document.getElementById('loadMoreMentorBtn')?.addEventListener('click', () => {
     visibleMentorCount += 12;
     renderMentorFinder(false);
   });


### PR DESCRIPTION
## 🚀 Program
- [x] GSSOC
- [ ] NSOC
- [ ] General Contribution

## 📝 Description
Added a "view more mentors" button, which will load 12 mentors at a time, and clicking again will show another 12 mentors.

## 🔗 Related Issue
Closes #1350 

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open the project files
2. Check that view more mentor button is properly functioning
3. Ensure no other content has been modified

<img width="1718" height="640" alt="Screenshot 2026-05-26 140304" src="https://github.com/user-attachments/assets/acef9ce7-ff75-48ff-b732-c71972c9c4f6" />

<img width="1031" height="825" alt="image" src="https://github.com/user-attachments/assets/7fa66d92-bd74-48fe-845b-8a18a678cd8b" />


## ✅ Checklist
- [x] I am contributing under GSSoC and NSOC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `docs: update mentor contact details`)