### PR TITLE
fix(ui): animate progress bars on panel expand, sync dark-mode CSS ov…

### DIFF
--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -93,12 +93,15 @@ function renderScoreBreakdownPanel(scoreBreakdown, panelId) {
     .map((domain) => `<span class="match-pill match-pill-domain">${safeEscapeHtml(domain)}</span>`)
     .join('');
 
-  const tagsHtml = (langPills || domainPills)
-    ? `<div class="match-pill-groups">
-        ${langPills ? `<div class="match-pill-group"><span class="match-pill-heading">Languages</span><div class="match-pill-list">${langPills}</div></div>` : ''}
-        ${domainPills ? `<div class="match-pill-group"><span class="match-pill-heading">Domains</span><div class="match-pill-list">${domainPills}</div></div>` : ''}
-       </div>`
-    : '';
+  let tagsHtml = '';
+  if (langPills || domainPills) {
+    const langGroupHtml = langPills ? `<div class="match-pill-group"><span class="match-pill-heading">Languages</span><div class="match-pill-list">${langPills}</div></div>` : '';
+    const domainGroupHtml = domainPills ? `<div class="match-pill-group"><span class="match-pill-heading">Domains</span><div class="match-pill-list">${domainPills}</div></div>` : '';
+    tagsHtml = `<div class="match-pill-groups">
+        ${langGroupHtml}
+        ${domainGroupHtml}
+       </div>`;
+  }
 
   return `
     <div class="match-breakdown-panel hidden" id="${panelId}" aria-hidden="true">

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -60,6 +60,52 @@ const safeEscapeHtml = (str) => {
     .replaceAll("'", '&#039;');
 };
 
+const BREAKDOWN_METRICS = [
+  { key: 'langScore', label: 'Language Fit' },
+  { key: 'topicScore', label: 'Domain Interest' },
+  { key: 'activityScore', label: 'Activity Match' },
+  { key: 'experienceScore', label: 'Experience Level' },
+];
+
+function renderScoreBreakdownPanel(scoreBreakdown, panelId) {
+  if (!scoreBreakdown?.breakdown) return '';
+
+  const barsHtml = BREAKDOWN_METRICS.map(({ key, label }) => {
+    const item = scoreBreakdown.breakdown[key] || { score: 0, max: 1 };
+    const pct = item.max > 0 ? Math.round((item.score / item.max) * 100) : 0;
+    return `
+      <div class="match-bar-row">
+        <div class="match-bar-header">
+          <span class="match-bar-label">${label}</span>
+          <span class="match-bar-points">${item.score}/${item.max} pts</span>
+        </div>
+        <div class="match-bar" role="progressbar" aria-valuenow="${item.score}" aria-valuemin="0" aria-valuemax="${item.max}" aria-label="${label}">
+          <div class="match-bar-fill" style="--match-pct: ${pct}%"></div>
+        </div>
+      </div>`;
+  }).join('');
+
+  const langPills = (scoreBreakdown.matchedLanguages || [])
+    .map((lang) => `<span class="match-pill match-pill-lang">${safeEscapeHtml(lang)}</span>`)
+    .join('');
+  const domainPills = (scoreBreakdown.matchedDomains || [])
+    .map((domain) => `<span class="match-pill match-pill-domain">${safeEscapeHtml(domain)}</span>`)
+    .join('');
+
+  const tagsHtml = (langPills || domainPills)
+    ? `<div class="match-pill-groups">
+        ${langPills ? `<div class="match-pill-group"><span class="match-pill-heading">Languages</span><div class="match-pill-list">${langPills}</div></div>` : ''}
+        ${domainPills ? `<div class="match-pill-group"><span class="match-pill-heading">Domains</span><div class="match-pill-list">${domainPills}</div></div>` : ''}
+       </div>`
+    : '';
+
+  return `
+    <div class="match-breakdown-panel hidden" id="${panelId}" aria-hidden="true">
+      <div class="match-breakdown-bars">${barsHtml}</div>
+      ${tagsHtml}
+    </div>`;
+}
+
 
 function handleBookmarkAction(e, btn) {
   e.stopPropagation();
@@ -218,6 +264,31 @@ document.addEventListener('DOMContentLoaded', () => {
       if (compareBtn && card) {
         return handleCompareAction(e, compareBtn, card);
       }
+
+      const breakdownBtn = target.closest('[data-breakdown-toggle]');
+      if (breakdownBtn) {
+        e.stopPropagation();
+        const panelId = breakdownBtn.getAttribute('aria-controls');
+        const panel = panelId ? document.getElementById(panelId) : null;
+        if (!panel) return;
+
+        const isOpen = !panel.classList.contains('hidden');
+        panel.classList.toggle('hidden', isOpen);
+        panel.setAttribute('aria-hidden', String(isOpen));
+        breakdownBtn.setAttribute('aria-expanded', String(!isOpen));
+        breakdownBtn.classList.toggle('is-open', !isOpen);
+
+        if (!isOpen) {
+          const fills = panel.querySelectorAll('.match-bar-fill');
+          fills.forEach(el => el.style.width = '0%');
+          requestAnimationFrame(() => {
+            fills.forEach(el => {
+              el.style.width = el.style.getPropertyValue('--match-pct') || '0%';
+            });
+          });
+        }
+        return;
+      }
       
       if (card) {
         return handleCardActivation(card);
@@ -234,8 +305,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const currentCompareList = globalThis.compareList || [];
     const currentBookmarkedSet = globalThis.bookmarkedSet || new Set();
 
-    const html = recs.map(rec => {
+    const html = recs.map((rec, recIndex) => {
       const o = rec.org;
+      const breakdownPanelId = `match-breakdown-${recIndex}`;
       const githubOwner = o.github ? o.github.split('/')[0] : '';
       const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
       
@@ -298,6 +370,18 @@ document.addEventListener('DOMContentLoaded', () => {
               ${reasonsHtml}
             </ul>
             ${matchedSkillsHtml}
+          </div>
+
+          <div class="match-breakdown-wrap mt-3">
+            <button type="button"
+                    class="match-breakdown-toggle"
+                    data-breakdown-toggle
+                    aria-expanded="false"
+                    aria-controls="${breakdownPanelId}">
+              View Score Breakdown
+              <span class="match-breakdown-chevron material-symbols-outlined" aria-hidden="true">expand_more</span>
+            </button>
+            ${renderScoreBreakdownPanel(rec.scoreBreakdown, breakdownPanelId)}
           </div>
         </div>
 

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -1,6 +1,6 @@
 // src/js/recommendation-ui.js
 
-/* global analyzeGitHubUser, extractSkills, getRecommendations, escapeHtml, openModal, toggleCompare, toggleBookmark */
+/* global analyzeGitHubUser, extractSkills, getRecommendations, escapeHtml, openModal, toggleCompare, toggleBookmark, SCORE_METRIC_KEYS */
 
 let currentAbortController = null;
 let currentRequestId = 0;
@@ -60,12 +60,20 @@ const safeEscapeHtml = (str) => {
     .replaceAll("'", '&#039;');
 };
 
+const METRIC_KEYS = (typeof SCORE_METRIC_KEYS !== 'undefined' ? SCORE_METRIC_KEYS : null) || {
+  LANG: 'langScore',
+  TOPIC: 'topicScore',
+  ACTIVITY: 'activityScore',
+  EXPERIENCE: 'experienceScore',
+  STABILITY: 'stabilityScore',
+};
+
 const BREAKDOWN_METRICS = [
-  { key: 'langScore', label: 'Language Fit' },
-  { key: 'topicScore', label: 'Domain Interest' },
-  { key: 'activityScore', label: 'Activity Match' },
-  { key: 'experienceScore', label: 'Experience Level' },
-  { key: 'stabilityScore', label: 'Stability Bonus' },
+  { key: METRIC_KEYS.LANG, label: 'Language Fit' },
+  { key: METRIC_KEYS.TOPIC, label: 'Domain Interest' },
+  { key: METRIC_KEYS.ACTIVITY, label: 'Activity Match' },
+  { key: METRIC_KEYS.EXPERIENCE, label: 'Experience Level' },
+  { key: METRIC_KEYS.STABILITY, label: 'Stability Bonus' },
 ];
 
 function renderScoreBreakdownPanel(scoreBreakdown, panelId) {

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -65,6 +65,7 @@ const BREAKDOWN_METRICS = [
   { key: 'topicScore', label: 'Domain Interest' },
   { key: 'activityScore', label: 'Activity Match' },
   { key: 'experienceScore', label: 'Experience Level' },
+  { key: 'stabilityScore', label: 'Stability Bonus' },
 ];
 
 function renderScoreBreakdownPanel(scoreBreakdown, panelId) {

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -2,6 +2,20 @@
 
 /* global ORGS */
 
+const SCORE_BREAKDOWN_MAX = {
+  lang: 40,
+  topic: 30,
+  activity: 15,
+  experience: 15,
+};
+
+function formatSkillLabel(skill) {
+  return String(skill)
+    .split(/[\s_-]+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
 /**
  * Retrieves the top 6 recommended organizations based on skills and profile.
  * 
@@ -48,7 +62,9 @@ function calculateLanguageScore(userLanguages, orgTags, orgCat, matchedSkills, m
   });
 
   const langMatches = primaryLangs.length;
-  if (langMatches === 0) return 0;
+  if (langMatches === 0) {
+    return { score: 0, matched: [] };
+  }
 
   let langDelta = 0;
   if (langMatches >= 1) langDelta += 15;
@@ -58,7 +74,10 @@ function calculateLanguageScore(userLanguages, orgTags, orgCat, matchedSkills, m
 
   const displayLangs = primaryLangs.slice(0, 2).join(", ");
   matchReasons.push(`Strong stack match: ${displayLangs}${primaryLangs.length > 2 ? '...' : ''}`);
-  return Math.min(langDelta, 40);
+  return {
+    score: Math.min(langDelta, SCORE_BREAKDOWN_MAX.lang),
+    matched: primaryLangs,
+  };
 }
 
 function calculateTopicScore(userTopics, orgTags, orgCat, matchedSkills, matchReasons) {
@@ -71,7 +90,9 @@ function calculateTopicScore(userTopics, orgTags, orgCat, matchedSkills, matchRe
   });
 
   const topicMatches = matchedTopics.length;
-  if (topicMatches === 0) return 0;
+  if (topicMatches === 0) {
+    return { score: 0, matched: [] };
+  }
 
   let topicDelta = 0;
   if (topicMatches >= 1) topicDelta += 12;
@@ -79,7 +100,10 @@ function calculateTopicScore(userTopics, orgTags, orgCat, matchedSkills, matchRe
   if (topicMatches >= 3) topicDelta += 8;
 
   matchReasons.push(`Fits your interests in ${matchedTopics[0]}`);
-  return Math.min(topicDelta, 30);
+  return {
+    score: Math.min(topicDelta, SCORE_BREAKDOWN_MAX.topic),
+    matched: matchedTopics,
+  };
 }
 
 function calculateActivityScore(githubProfile, org, matchReasons) {
@@ -146,13 +170,15 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
   const orgTags = new Set((org.tags || []).map(t => orgNormalize(t.toLowerCase())));
   const orgCat = org.cat ? orgNormalize(org.cat.toLowerCase()) : '';
 
-  let score = 0;
-  
-  score += calculateLanguageScore(userLanguages, orgTags, orgCat, matchedSkills, matchReasons);
-  score += calculateTopicScore(userTopics, orgTags, orgCat, matchedSkills, matchReasons);
-  score += calculateActivityScore(githubProfile, org, matchReasons);
-  score += calculateExperienceScore(githubProfile, org, matchReasons);
-  score += calculateStabilityBonus(org, matchReasons);
+  const langResult = calculateLanguageScore(userLanguages, orgTags, orgCat, matchedSkills, matchReasons);
+  const topicResult = calculateTopicScore(userTopics, orgTags, orgCat, matchedSkills, matchReasons);
+  const activityScore = calculateActivityScore(githubProfile, org, matchReasons);
+  const experienceScore = calculateExperienceScore(githubProfile, org, matchReasons);
+  const stabilityBonus = calculateStabilityBonus(org, matchReasons);
+
+  const experienceDisplayScore = Math.min(experienceScore, SCORE_BREAKDOWN_MAX.experience);
+
+  let score = langResult.score + topicResult.score + activityScore + experienceScore + stabilityBonus;
 
   const cappedScore = Math.min(Math.round(score), 99);
   const tieBreaker = (org.name.length % 10) / 100 + (index % 100) / 10000;
@@ -162,13 +188,32 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
     matchReasons.push("Matches your general developer profile");
   }
 
+  const matchedDomains = [...new Set(topicResult.matched)];
+  if (org.cat && !matchedDomains.includes(orgNormalize(org.cat.toLowerCase()))) {
+    const catNorm = orgNormalize(org.cat.toLowerCase());
+    if (userTopics.has(catNorm) || userLanguages.has(catNorm)) {
+      matchedDomains.unshift(catNorm);
+    }
+  }
+
   return {
     orgIndex: index,
     org: org,
-    score: cappedScore, 
+    score: cappedScore,
     rawScore: finalRawScore,
     matchedSkills: [...new Set(matchedSkills)],
-    reasons: matchReasons
+    reasons: matchReasons,
+    scoreBreakdown: {
+      total: cappedScore,
+      breakdown: {
+        langScore: { score: langResult.score, max: SCORE_BREAKDOWN_MAX.lang },
+        topicScore: { score: topicResult.score, max: SCORE_BREAKDOWN_MAX.topic },
+        activityScore: { score: activityScore, max: SCORE_BREAKDOWN_MAX.activity },
+        experienceScore: { score: experienceDisplayScore, max: SCORE_BREAKDOWN_MAX.experience },
+      },
+      matchedLanguages: langResult.matched.map(formatSkillLabel),
+      matchedDomains: matchedDomains.map(formatSkillLabel),
+    },
   };
 }
 

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -12,9 +12,14 @@ const SCORE_BREAKDOWN_MAX = {
 
 function formatSkillLabel(skill) {
   return String(skill)
-    .split(/[\s_-]+/)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
+    .split('/')
+    .map((part) =>
+      part
+        .split(/[\s_-]+/)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ')
+    )
+    .join('/');
 }
 
 /**
@@ -177,7 +182,7 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
   const experienceScore = calculateExperienceScore(githubProfile, org, matchReasons);
   const stabilityBonus = calculateStabilityBonus(org, matchReasons);
 
-  let score = langResult.score + topicResult.score + activityScore + experienceScore + stabilityBonus;
+  const score = langResult.score + topicResult.score + activityScore + experienceScore + stabilityBonus;
 
   const cappedScore = Math.min(Math.round(score), 99);
   const tieBreaker = (org.name.length % 10) / 100 + (index % 100) / 10000;

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -6,7 +6,8 @@ const SCORE_BREAKDOWN_MAX = {
   lang: 40,
   topic: 30,
   activity: 15,
-  experience: 15,
+  experience: 25,
+  stability: 10,
 };
 
 function formatSkillLabel(skill) {
@@ -176,8 +177,6 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
   const experienceScore = calculateExperienceScore(githubProfile, org, matchReasons);
   const stabilityBonus = calculateStabilityBonus(org, matchReasons);
 
-  const experienceDisplayScore = Math.min(experienceScore, SCORE_BREAKDOWN_MAX.experience);
-
   let score = langResult.score + topicResult.score + activityScore + experienceScore + stabilityBonus;
 
   const cappedScore = Math.min(Math.round(score), 99);
@@ -209,7 +208,8 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
         langScore: { score: langResult.score, max: SCORE_BREAKDOWN_MAX.lang },
         topicScore: { score: topicResult.score, max: SCORE_BREAKDOWN_MAX.topic },
         activityScore: { score: activityScore, max: SCORE_BREAKDOWN_MAX.activity },
-        experienceScore: { score: experienceDisplayScore, max: SCORE_BREAKDOWN_MAX.experience },
+        experienceScore: { score: experienceScore, max: SCORE_BREAKDOWN_MAX.experience },
+        stabilityScore: { score: stabilityBonus, max: SCORE_BREAKDOWN_MAX.stability },
       },
       matchedLanguages: langResult.matched.map(formatSkillLabel),
       matchedDomains: matchedDomains.map(formatSkillLabel),

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -2,6 +2,14 @@
 
 /* global ORGS */
 
+const SCORE_METRIC_KEYS = {
+  LANG: 'langScore',
+  TOPIC: 'topicScore',
+  ACTIVITY: 'activityScore',
+  EXPERIENCE: 'experienceScore',
+  STABILITY: 'stabilityScore',
+};
+
 const SCORE_BREAKDOWN_MAX = {
   lang: 40,
   topic: 30,
@@ -210,11 +218,11 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
     scoreBreakdown: {
       total: cappedScore,
       breakdown: {
-        langScore: { score: langResult.score, max: SCORE_BREAKDOWN_MAX.lang },
-        topicScore: { score: topicResult.score, max: SCORE_BREAKDOWN_MAX.topic },
-        activityScore: { score: activityScore, max: SCORE_BREAKDOWN_MAX.activity },
-        experienceScore: { score: experienceScore, max: SCORE_BREAKDOWN_MAX.experience },
-        stabilityScore: { score: stabilityBonus, max: SCORE_BREAKDOWN_MAX.stability },
+        [SCORE_METRIC_KEYS.LANG]: { score: langResult.score, max: SCORE_BREAKDOWN_MAX.lang },
+        [SCORE_METRIC_KEYS.TOPIC]: { score: topicResult.score, max: SCORE_BREAKDOWN_MAX.topic },
+        [SCORE_METRIC_KEYS.ACTIVITY]: { score: activityScore, max: SCORE_BREAKDOWN_MAX.activity },
+        [SCORE_METRIC_KEYS.EXPERIENCE]: { score: experienceScore, max: SCORE_BREAKDOWN_MAX.experience },
+        [SCORE_METRIC_KEYS.STABILITY]: { score: stabilityBonus, max: SCORE_BREAKDOWN_MAX.stability },
       },
       matchedLanguages: langResult.matched.map(formatSkillLabel),
       matchedDomains: matchedDomains.map(formatSkillLabel),
@@ -222,8 +230,9 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
   };
 }
 
+globalThis.SCORE_METRIC_KEYS = SCORE_METRIC_KEYS;
 globalThis.getRecommendations = getRecommendations;
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { getRecommendations };
+  module.exports = { getRecommendations, SCORE_METRIC_KEYS };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -867,7 +867,7 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 .match-pill{display:inline-flex;align-items:center;padding:3px 10px;border-radius:100px;font-size:10px;font-weight:700;border:1px solid transparent}
 .match-pill-lang{background:var(--white);border-color:var(--green);color:var(--green)}
 .match-pill-domain{background:var(--white);border-color:var(--blue);color:var(--blue)}
-.match-pill-lang::before,.match-pill-domain::before{content:'';display:inline-block;width:6px;height:6px;border-radius:50%;margin-right:6px;background:currentColor}
+.match-pill-lang::before,.match-pill-domain::before{content:'';display:inline-block;width:6px;height:6px;border-radius:50%;margin-right:6px;background:currentcolor}
 @media(max-width:640px){
   .match-breakdown-panel{padding:10px}
   .match-bar-label{font-size:10px}

--- a/src/styles.css
+++ b/src/styles.css
@@ -843,4 +843,43 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
   color: #a1a1aa;
 }
 
-
+/* ── AI Match Score Breakdown ── */
+.match-breakdown-wrap{border-top:1px solid var(--border2);padding-top:10px}
+.match-breakdown-toggle{display:flex;align-items:center;justify-content:space-between;width:100%;gap:8px;padding:6px 0;border:none;background:transparent;color:var(--orange-deep);font-family:'Plus Jakarta Sans',sans-serif;font-size:11px;font-weight:700;cursor:pointer;text-align:left;transition:color .18s}
+.match-breakdown-toggle:hover{color:var(--orange)}
+.match-breakdown-toggle.is-open{color:var(--orange)}
+.match-breakdown-chevron{font-size:18px;transition:transform .25s ease}
+.match-breakdown-toggle.is-open .match-breakdown-chevron{transform:rotate(180deg)}
+.match-breakdown-panel{margin-top:10px;padding:12px;background:var(--orange-pale);border:1px solid var(--orange-border);border-radius:12px}
+.match-breakdown-panel.hidden{display:none}
+.match-breakdown-bars{display:flex;flex-direction:column;gap:10px}
+.match-bar-row{display:flex;flex-direction:column;gap:4px}
+.match-bar-header{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.match-bar-label{font-size:11px;font-weight:700;color:var(--ink2)}
+.match-bar-points{font-size:10px;font-weight:700;color:var(--muted);white-space:nowrap}
+.match-bar{height:8px;border-radius:100px;background:var(--border2);overflow:hidden}
+.match-bar-fill{height:100%;width:0;border-radius:100px;background:linear-gradient(90deg,var(--orange),var(--green));transition:width .6s cubic-bezier(.4,0,.2,1)}
+.match-breakdown-panel:not(.hidden) .match-bar-fill{width:var(--match-pct,0%)}
+.match-pill-groups{display:flex;flex-direction:column;gap:8px;margin-top:12px;padding-top:10px;border-top:1px dashed var(--orange-border)}
+.match-pill-group{display:flex;flex-direction:column;gap:6px}
+.match-pill-heading{font-size:9px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+.match-pill-list{display:flex;flex-wrap:wrap;gap:6px}
+.match-pill{display:inline-flex;align-items:center;padding:3px 10px;border-radius:100px;font-size:10px;font-weight:700;border:1px solid transparent}
+.match-pill-lang{background:var(--white);border-color:var(--green);color:var(--green)}
+.match-pill-domain{background:var(--white);border-color:var(--blue);color:var(--blue)}
+.match-pill-lang::before,.match-pill-domain::before{content:'';display:inline-block;width:6px;height:6px;border-radius:50%;margin-right:6px;background:currentColor}
+@media(max-width:640px){
+  .match-breakdown-panel{padding:10px}
+  .match-bar-label{font-size:10px}
+  .match-bar-points{font-size:9px}
+}
+[data-theme="dark"] .match-breakdown-wrap{border-top-color:var(--border)}
+[data-theme="dark"] .match-breakdown-toggle{color:var(--orange-deep)}
+[data-theme="dark"] .match-breakdown-toggle:hover,[data-theme="dark"] .match-breakdown-toggle.is-open{color:var(--orange)}
+[data-theme="dark"] .match-breakdown-panel{background:var(--orange-pale);border-color:var(--orange-border)}
+[data-theme="dark"] .match-bar-label{color:var(--ink2)}
+[data-theme="dark"] .match-bar-points{color:var(--muted)}
+[data-theme="dark"] .match-bar{background:var(--border2)}
+[data-theme="dark"] .match-pill-groups{border-top-color:var(--orange-border)}
+[data-theme="dark"] .match-pill-heading{color:var(--muted)}
+[data-theme="dark"] .match-pill-lang,[data-theme="dark"] .match-pill-domain{background:var(--card-bg)}


### PR DESCRIPTION
##program: gssoc

## Description

Fixes the "Comprehensive AI Match Score Breakdown" visual panel to ensure progress bars animate smoothly on expand, and syncs dark-mode CSS overrides between `index.html` and `src/styles.css`.

### Changes

- **`src/js/recommendation-ui.js`**: Added `requestAnimationFrame` reflow in the toggle handler so `.match-bar-fill` transitions from `0%` → target width when the panel opens (previously the CSS transition never fired after `display: none`).
- **`src/styles.css`**: Added 8 missing `[data-theme="dark"]` overrides (`.match-breakdown-wrap`, `.match-breakdown-toggle`, `.match-bar-label`, `.match-bar-points`, `.match-bar`, `.match-pill-groups`, `.match-pill-heading`) using CSS variables for consistency.

### Related Issue

Closes #961

### Checklist

- [ ] Issue is assigned to me
- [ ] PR links an issue
- [ ] Changes are focused and minimal
- [ ] No unnecessary dependencies added
- [ ] Code follows repository architecture
- [ ] I understand the code submitted
- [ ] Screenshots attached