### PR TITLE
fix: resolve stale issues banner dark mode inconsistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -2463,13 +2463,13 @@ sections.forEach(sectionId => {
     // Soften banner background to neutral
     if (issuesBanner) {
       issuesBanner.classList.remove('bg-green-50', 'border-green-200');
-      issuesBanner.classList.add('bg-zinc-50', 'border-zinc-200');
+      issuesBanner.classList.add("bg-zinc-50","dark:bg-zinc-800","border-zinc-200","dark:border-zinc-700");
       const title = document.getElementById('issuesBannerTitle');
-      if (title) { title.classList.remove('text-green-800'); title.classList.add('text-zinc-800'); }
+      if (title) { title.classList.remove('text-green-800'); title.classList.add("text-zinc-800", "dark:text-zinc-100"); }
       const subtitle = document.getElementById('issuesBannerSubtitle');
-      if (subtitle) { subtitle.classList.remove('text-green-600'); subtitle.classList.add('text-zinc-500'); }
+      if (subtitle) { subtitle.classList.remove('text-green-600'); subtitle.classList.add("text-zinc-500", "dark:text-zinc-400"); }
       const lastUpdated = document.getElementById('issuesLastUpdated');
-      if (lastUpdated) { lastUpdated.classList.remove('text-green-600'); lastUpdated.classList.add('text-zinc-500'); }
+      if (lastUpdated) { lastUpdated.classList.remove('text-green-600'); lastUpdated.classList.add("text-zinc-500", "dark:text-zinc-400"); }
     }
 
     // --- Mentor Finder banner ---


### PR DESCRIPTION
program: gssoc

## Description

Fixes stale issues banner dark mode inconsistency by adding dark-mode compatible stale-state classes.

Previously, the stale issues banner retained light-theme styling in dark mode, resulting in inconsistent UI appearance.

This update ensures correct dark-mode rendering while preserving the intended muted stale-state visual distinction.

## Related Issue

Closes #1470

## Type of Change

* [x] Bug fix

## Visual Validation

### Before Fix

<img width="1868" height="949" alt="Screenshot 2026-05-29 020443" src="https://github.com/user-attachments/assets/602955b4-3f17-488e-91b2-3f03e13c2ffa" />

### After Fix

<img width="1887" height="952" alt="Screenshot 2026-05-29 035544" src="https://github.com/user-attachments/assets/5e0c64f3-19ee-4d85-9716-7abb9d8cf8dd" />

## Testing

* Tested locally using `vercel dev`
* Verified dark mode rendering
* Verified light mode rendering
* Tested theme toggle behavior
* Confirmed no console errors

## Checklist

* [x] Issue assigned to me
* [x] Changes tested locally
* [x] No unnecessary dependencies added
* [x] Changes are focused and minimal
* [x] Commit includes DCO sign-off
* [x] Screenshots attached
