### PR TITLE
fix(data): add mentor contact info for Django Software Foundation

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -835,18 +835,90 @@
   "Django Software Foundation": {
     "org": "Django Software Foundation",
     "ideasUrl": "https://code.djangoproject.com/wiki/SummerOfCode2026",
-    "channels": [],
-    "mentors": [],
+    "channels": [
+      {
+        "type": "Forum",
+        "url": "https://forum.djangoproject.com/c/internals/mentorship/10",
+        "label": "Django Forum - Mentorship channel"
+      },
+      {
+        "type": "Discord",
+        "url": "https://chat.djangoproject.com",
+        "label": "Django Discord"
+      },
+      {
+        "type": "IRC",
+        "url": "https://web.libera.chat/#django-dev",
+        "label": "#django-dev on Libera.Chat"
+      },
+      {
+        "type": "IRC",
+        "url": "https://web.libera.chat/#django",
+        "label": "#django on Libera.Chat"
+      }
+    ],
+    "mentors": [
+      {
+        "name": "Andrew Miller",
+        "github": "nanorepublica",
+        "githubUrl": "https://github.com/nanorepublica"
+      },
+      {
+        "name": "Sarah Boyce",
+        "github": "sarahboyce",
+        "githubUrl": "https://github.com/sarahboyce"
+      },
+      {
+        "name": "Bhuvnesh Sharma",
+        "github": "DevilsAutumn",
+        "githubUrl": "https://github.com/DevilsAutumn"
+      },
+      {
+        "name": "Jacob Walls",
+        "github": "jacobtylerwalls",
+        "githubUrl": "https://github.com/jacobtylerwalls"
+      },
+      {
+        "name": "Saptak Sengupta",
+        "github": "SaptakS",
+        "githubUrl": "https://github.com/saptaks"
+      },
+      {
+        "name": "Sarah Abderemane",
+        "github": "sabderemane",
+        "githubUrl": "https://github.com/sabderemane"
+      },
+      {
+        "name": "Apoorv Garg",
+        "github": "Apoorvgarg-creator",
+        "githubUrl": "https://github.com/Apoorvgarg-creator"
+      },
+      {
+        "name": "Thibaut Decombe",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Sage Abdullah",
+        "github": "laymonage",
+        "githubUrl": "https://github.com/laymonage"
+      },
+      {
+        "name": "Simon Charette",
+        "github": "charettes",
+        "githubUrl": "https://github.com/charettes"
+      }
+    ],
     "mailingLists": [
       {
         "type": "Mailing list",
-        "url": "https://groups.google.com/g/django-developers/c/at-G0hZrfXE",
-        "label": "​ https://groups.google.com/g/django-developers/c/at-G0hZrfXE"
+        "url": "https://groups.google.com/g/django-developers",
+        "label": "django-developers Google Group"
       }
     ],
-    "tip": "Send a short intro email with your background and the idea you're interested in.",
+    "tip": "Post your draft proposal to the Django Forum Mentorship channel for feedback. Start contributing to Django before applying to become a known contributor.",
     "status": "ok",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "lastFetched": "2026-05-29T00:00:00.000Z"
   },
   "dora-rs": {
     "org": "dora-rs",


### PR DESCRIPTION
## Program
GSSoC (program: gssoc)

## Description
Manually researched and verified mentor contact info for Django Software Foundation (GSoC 2026).

- Added channels: Django Forum Mentorship, Django Discord, #django-dev and #django IRC (Libera.Chat)
- Added 10 mentors with verified GitHub handles: Andrew Miller (nanorepublica), Sarah Boyce (sarahboyce), Sarah Abderemane (sabderemane), Bhuvnesh Sharma (DevilsAutumn), Jacob Walls (jacobtylerwalls), Saptak Sengupta (SaptakS), Apoorv Garg (Apoorvgarg-creator), Sage Abdullah (laymonage), Simon Charette (charettes), Thibaut Decombe (handle not found)
- Updated mailing list label
- Updated tip to reflect actual contact process (post on Forum + contribute first)
- Set status: ok

## Related Issue
Closes #284

## Type of Change
- [x] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `data/mentors.json`
2. Find the `"Django Software Foundation"` entry
3. Verify channels, mentors, and status fields are populated correctly

## Screenshots (if applicable)
N/A - data-only change

##  Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
