### PR TITLE
fix: clone headers in fetchWithFallback to prevent shared ghHeaders mutation

### DIFF
--- a/api/github.js
+++ b/api/github.js
@@ -53,13 +53,19 @@ export default async function handler(req) {
     ghHeaders.Authorization = `Bearer ${token}`;
   }
 
-  // Helper to fallback to unauthenticated request if token is invalid (401)
+  // Helper to fallback to unauthenticated request if token is invalid (401).
+  // A shallow clone of options.headers is used for the retry so that the
+  // shared ghHeaders object is never mutated and all other calls in this
+  // invocation continue to send the Authorization header normally.
   const fetchWithFallback = async (url, options) => {
     let res = await fetch(url, options);
     if (res.status === 401 && options.headers?.Authorization) {
-      // Remove authorization for this retry and all future requests in this invocation
-      delete options.headers.Authorization;
-      res = await fetch(url, options);
+      const retryOptions = {
+        ...options,
+        headers: { ...options.headers },
+      };
+      delete retryOptions.headers.Authorization;
+      res = await fetch(url, retryOptions);
     }
     return res;
   };


### PR DESCRIPTION
## 🚀 Program
GSSoC

program: gssoc

## 📝 Description

`fetchWithFallback` in `api/github.js` retried a failing 401 request by calling `delete options.headers.Authorization`. Because every call in the same edge function invocation passes the same `ghHeaders` object as `options.headers`, this deletion was permanent for the entire invocation lifetime. All subsequent GitHub API calls silently lost their auth token and fell back to the 60 req/hr unauthenticated rate limit.

The fix creates shallow copies of both `options` and `options.headers` before the retry, so the deletion is strictly scoped to that one failing request. The shared `ghHeaders` object is never modified.

**Before:**
```js
const fetchWithFallback = async (url, options) => {
  let res = await fetch(url, options);
  if (res.status === 401 && options.headers?.Authorization) {
    delete options.headers.Authorization; // mutates shared ghHeaders
    res = await fetch(url, options);
  }
  return res;
};
```

**After:**
```js
const fetchWithFallback = async (url, options) => {
  let res = await fetch(url, options);
  if (res.status === 401 && options.headers?.Authorization) {
    const retryOptions = {
      ...options,
      headers: { ...options.headers },
    };
    delete retryOptions.headers.Authorization;
    res = await fetch(url, retryOptions);
  }
  return res;
};
```

## 🔗 Related Issue
Closes #1336

## 🔄 Type of Change
- [x] 🐛 Bug fix

## 🧪 How to Test

1. Set `GITHUB_TOKEN` in your environment to an expired or invalid token.
2. Send a request to `/api/github?user=someuser`.
3. Observe that the invocation still completes without all pages falling back to unauthenticated requests.
4. Verify that `ghHeaders.Authorization` is still present after the fallback retry by adding a temporary log line after the `fetchWithFallback` call.

Alternatively:

1. Set `GITHUB_TOKEN` to a valid token.
2. Trigger a request where the first page returns 401 (e.g. by temporarily scoping the token incorrectly).
3. Confirm that only the page that triggered 401 retries unauthenticated; pages 2 and 3 still carry the Authorization header.

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `fix: clone headers in fetchWithFallback to prevent shared ghHeaders mutation`)