### PR TITLE
chore: Add .env.example for contributor onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+﻿# GitHub API token for live stats and Good First Issues (required)
+# Generate at https://github.com/settings/tokens — only public_repo scope needed
+GITHUB_TOKEN=ghp_your_token_here

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-﻿# GitHub API token for live stats and Good First Issues (required)
+# GitHub API token for live stats and Good First Issues (required)
 # Generate at https://github.com/settings/tokens — only public_repo scope needed
 GITHUB_TOKEN=ghp_your_token_here


### PR DESCRIPTION
﻿## Description
Add a `.env.example` file to document the required environment variables for local development and deployment.

## Related Issue
Closes #1564

## Problem Statement
The README mentions needing a `GITHUB_TOKEN` environment variable, but there's no `.env.example` file to show contributors what variables are needed. New contributors have to read through the full README to find this information.

## Proposed Solution
- Create `.env.example` at project root documenting `GITHUB_TOKEN`
- `.env` is already in `.gitignore` (confirmed)

## Acceptance Criteria
- [x] `.env.example` exists at project root
- [x] Documents GITHUB_TOKEN as required
- [x] `.env` already in `.gitignore`

## Program
program: gssoc

## GSSoC
- [ ] I am a registered GSSoC 2026 contributor
- [ ] I would like to implement this feature myself
