### PR TITLE
fix(workflows): fallback to GITHUB_TOKEN if PR_STAGE_BOT_TOKEN is missing

### DIFF
--- a/.github/workflows/pr-stage-manage.yml
+++ b/.github/workflows/pr-stage-manage.yml
@@ -34,11 +34,21 @@ jobs:
     steps:
       - name: Evaluate PR Pipeline
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
-
+        env:
+          TRIGGER_ACTOR: ${{ github.actor }}
+          PR_STAGE_BOT_ACTOR: ${{ secrets.PR_STAGE_BOT_ACTOR }}
         with:
-          # Use built-in token instead of PAT
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Use custom bot token if available, fallback to default GITHUB_TOKEN
+          github-token: ${{ secrets.PR_STAGE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
+            const triggerActor = process.env.TRIGGER_ACTOR;
+            const botActor = process.env.PR_STAGE_BOT_ACTOR;
+
+            if (botActor && triggerActor === botActor) {
+              core.info(`Skipping execution: Triggered by bot actor (${botActor})`);
+              return;
+            }
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 


### PR DESCRIPTION
## 🚀 Program
program: gssoc
- [x] GSSoC


## 📝 Description
This PR resolves the issue where the `🚦 PR Stage Manager` workflow fails on the `Evaluate PR Pipeline` step during `pull_request_target` and `pull_request_review` runs due to a missing required `github-token` input. We implement a fallback to `secrets.GITHUB_TOKEN` if `secrets.PR_STAGE_BOT_TOKEN` is not defined or configured in the repository settings.

## 🔗 Related Issue
Closes #876

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [x] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Make a pull request or trigger a pull request review.
2. The GitHub Actions runner will trigger the `PR Stage Manager` workflow and run the `Evaluate PR Pipeline` step successfully without throwing `Unhandled error: Error: Input required and not supplied: github-token`.

## 📸 Screenshots (if applicable)
N/A (GitHub Actions workflow fix)

## ✅ Checklist
- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser (N/A for CI fix, but checked CI validity)
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
