### PR TITLE
Fix: search scroll issue caused by grid re-render

### DIFF
--- a/index.html
+++ b/index.html
@@ -3655,7 +3655,7 @@ if(org.ideas){
     heroSearch.value = document.getElementById('searchInput')?.value || new URLSearchParams(location.search).get('q') || '';
     heroSearch.addEventListener('input', (e) => {
       document.getElementById('searchInput').value = e.target.value;
-      document.getElementById('orgs').scrollIntoView({ behavior: 'smooth' });
+
       
       // Track search badge when user types in hero search
       const query = e.target.value.trim();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -563,7 +563,6 @@ function orgMatchesLanguages(org, selectedLanguages) {
 }
 
 function applyFilters(){
-  // const prevScrollY = window.scrollY;
   const search = (document.getElementById('searchInput')?.value || '').trim().toLowerCase();
   const categoryValue = document.getElementById('categoryFilter')?.value || '';
   const cat = categoryValue === 'all' ? '' : categoryValue;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -563,7 +563,7 @@ function orgMatchesLanguages(org, selectedLanguages) {
 }
 
 function applyFilters(){
-  const prevScrollY = window.scrollY;
+  // const prevScrollY = window.scrollY;
   const search = (document.getElementById('searchInput')?.value || '').trim().toLowerCase();
   const categoryValue = document.getElementById('categoryFilter')?.value || '';
   const cat = categoryValue === 'all' ? '' : categoryValue;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -563,6 +563,7 @@ function orgMatchesLanguages(org, selectedLanguages) {
 }
 
 function applyFilters(){
+  const prevScrollY = window.scrollY;
   const search = (document.getElementById('searchInput')?.value || '').trim().toLowerCase();
   const categoryValue = document.getElementById('categoryFilter')?.value || '';
   const cat = categoryValue === 'all' ? '' : categoryValue;
@@ -645,7 +646,6 @@ function applyFilters(){
   focusedIdx=-1;
   renderGrid(res);
   document.getElementById('orgCount').textContent = res.length;
-
   // Sync filter state to URL
   const params = new URLSearchParams();
   if (search)    params.set('q',search);


### PR DESCRIPTION
## Contribution Program

GSSOC

## Related Issue

Closes #1600

## Description

This PR fixes an issue where the page would scroll unexpectedly while typing in the search bar.

The filtering process caused unnecessary layout shifts during re-rendering, resulting in a poor user experience.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] My code follows the project style guidelines
- [x] I have tested my changes locally
- [x] I have linked the related issue
- [x] My commits are signed off (DCO)