### PR TITLE
fix: load star icon on privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -8,8 +8,7 @@
   <link rel="canonical" href="https://findmygsoc.vercel.app/privacy.html" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" integrity="sha384-NPToXI2n6gWUtTP7kSreAjbTuFo/Ud8X117P3IzZKfYqse84nsxKYkLO4Q4Jwmiz" crossorigin="anonymous" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" integrity="sha384-9gQ8upeWZQ9/fPKaAGJuDpTMaZdwDhECBPX+H6i9vVTa3EllQ1skSXUr6bXADJRW" crossorigin="anonymous" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
+   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
 
   <script>
     // Tailwind Configuration

--- a/privacy.html
+++ b/privacy.html
@@ -9,6 +9,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" integrity="sha384-NPToXI2n6gWUtTP7kSreAjbTuFo/Ud8X117P3IzZKfYqse84nsxKYkLO4Q4Jwmiz" crossorigin="anonymous" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" integrity="sha384-9gQ8upeWZQ9/fPKaAGJuDpTMaZdwDhECBPX+H6i9vVTa3EllQ1skSXUr6bXADJRW" crossorigin="anonymous" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
+
   <script>
     // Tailwind Configuration
     tailwind.config = {


### PR DESCRIPTION
## Related Issue

Closes #1672

program: gssoc

## Description

This PR fixes the issue where the text `star` was displayed instead of the Material Symbols star icon on the Privacy Policy page.

### Changes Made

* Added the Material Symbols Outlined stylesheet import in `privacy.html`.
* Ensured the star icon renders correctly in the "Star & Contribute" button.


### Type of Change

* Bug Fix

 ## Checklist

- [x] Tested locally
- [x] Linked related issue
- [x] DCO sign-off included
- [x] Changes are limited to this issue

### Program

GSSoC 2026

<img width="1694" height="616" alt="image" src="https://github.com/user-attachments/assets/75e593e4-3046-4909-889f-bfd7015952a9" />
