### PR TITLE
feat: add clear filters reset button for better UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -1110,6 +1110,10 @@
         <option value="stars">GitHub Stars</option>
         <option value="gfi">Good First Issues</option>
       </select>
+      <button id="clearFiltersBtn" onclick="clearAllFilters()" class="px-4 py-2 bg-red-50 text-red-600 border border-red-100 rounded-xl text-xs font-bold hover:bg-red-100 transition-colors flex items-center gap-1" title="Clear all search and filters">
+        <span class="material-symbols-outlined text-sm">filter_alt_off</span>
+        Clear Filters
+      </button>
     </div>
   </div>
   
@@ -3630,9 +3634,22 @@ if(org.ideas){
       chip.classList.remove('bg-orange-600', 'text-white');
       chip.classList.add('bg-surface-container-highest');
     });
+    if (typeof activeChip !== 'undefined') {
+      activeChip = null;
+    }
 
-    filteredOrgs = [...ORGS];
-    renderOrgs(true);
+    // Reset selected languages
+    if (typeof selectedLanguages !== 'undefined') {
+      selectedLanguages.clear();
+      if (typeof renderSelectedLanguages === 'function') renderSelectedLanguages();
+      document.querySelectorAll('.pill').forEach(pill => {
+        pill.classList.remove('bg-primary', 'text-white', 'border-primary');
+        pill.classList.add('bg-surface-container-high', 'border-zinc-200');
+        pill.setAttribute('aria-pressed', 'false');
+      });
+    }
+
+    applyFilters();
   };
 
   document.getElementById('searchInput').addEventListener('input', () => {

--- a/index.html
+++ b/index.html
@@ -3638,12 +3638,19 @@ if(org.ideas){
       activeChip = null;
     }
 
+    // Reset matchAllLanguages
+    matchAllLanguages = false;
+    globalThis.matchAllLanguages = false;
+    const toggle = document.getElementById('matchAllLanguagesToggle');
+    if (toggle) toggle.checked = false;
+    if (typeof updateLanguageModeHint === 'function') updateLanguageModeHint();
+
     // Reset selected languages
     if (typeof selectedLanguages !== 'undefined') {
       selectedLanguages.clear();
       if (typeof renderSelectedLanguages === 'function') renderSelectedLanguages();
       document.querySelectorAll('.pill').forEach(pill => {
-        pill.classList.remove('bg-primary', 'text-white', 'border-primary');
+        pill.classList.remove('active', 'bg-primary', 'text-white', 'border-primary');
         pill.classList.add('bg-surface-container-high', 'border-zinc-200');
         pill.setAttribute('aria-pressed', 'false');
       });


### PR DESCRIPTION
## 🚀 Program
GSSOC 2026

## 📝 Description
This PR adds a dedicated "Clear Filters" button to the organization filtering section to improve user experience when navigating different filter combinations.

Changes made:
- Added a "Clear Filters" button alongside the sort dropdown (`#sortSelect`) using the site's design system tokens (red accents for clear actions).
- Updated the `clearAllFilters()` function in `index.html` to comprehensively reset all filter states. It now explicitly clears:
  - The main search input and hero search bar.
  - The category, complexity, and sorting dropdowns.
  - Quick-filter chips (resetting the `activeChip` tracker).
  - Selected tech stack/language pills (clearing the `selectedLanguages` set).
- Ensures `applyFilters()` is called immediately after a reset so the organization grid accurately re-renders without stale filter parameters.

##  Related Issue
Closes #556

##  Type of Change
- [ ]  Bug fix
- [x]  New feature
- [ ]  SEO improvement
- [x] Style / UI improvement
- [ ]  Accessibility improvement
- [ ]  Documentation
- [ ]  CI / configuration
- [ ]  Refactor / cleanup

##  How to Test
1. Open `index.html` in a browser.
2. Select a few filters (e.g., pick a language pill, set a dropdown category, and type in the search bar).
3. Observe that the org list filters down appropriately.
4. Click the new "Clear Filters" button next to the sorting dropdown.
5. Verify that all dropdowns, search bars, highlighted pills, and active chips reset to their default states.
6. Verify that the org list resets to show all 184 organizations.

##  Screenshots (if applicable)
Before
<img width="1232" height="32" alt="filters-before" src="https://github.com/user-attachments/assets/d06c61e8-8dde-4252-854f-307ef0a8ceae" />
After
<img width="1232" height="38" alt="filters-after" src="https://github.com/user-attachments/assets/13d9cb70-fea1-4c61-bfa4-d21c9adad8c0" />


##  Checklist
- [x] I am contributing as an independent/general contributor
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools