### PR TITLE
fix(data): add mentor contact info for GNU Project

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1622,17 +1622,68 @@
     "org": "GNU Project",
     "ideasUrl": "https://www.gnu.org/software/soc-projects/ideas-2026.html",
     "channels": [],
-    "mentors": [],
+    "mentors": [
+      {
+        "name": "Zoltán Kovács (GNU XaoS, GNU Aris)",
+        "github": "kovzol",
+        "githubUrl": "https://github.com/kovzol"
+      },
+      {
+        "name": "Simon Sobisch (GnuCOBOL)",
+        "github": "GitMensch",
+        "githubUrl": "https://github.com/GitMensch"
+      },
+      {
+        "name": "Nicolas Berthier (GnuCOBOL)",
+        "github": "nberth",
+        "githubUrl": "https://github.com/nberth"
+      },
+      {
+        "name": "Rocky Bernstein (libcdio)",
+        "github": "rocky",
+        "githubUrl": "https://github.com/rocky"
+      },
+      {
+        "name": "Sean O'Brien (GNU Boot)",
+        "github": "",
+        "githubUrl": ""
+      },
+      {
+        "name": "Adrien Bourmault / neox (GNU Boot)",
+        "github": "",
+        "githubUrl": ""
+      }
+    ],
     "mailingLists": [
       {
         "type": "Mailing list",
-        "url": "http://lists.gnu.org/mailman/listinfo/summer-of-code/",
-        "label": "GNU Project Mailing list"
+        "url": "mailto:summer-of-code@gnu.org",
+        "label": "summer-of-code@gnu.org — GNU GSoC umbrella discussion"
+      },
+      {
+        "type": "Mailing list",
+        "url": "https://lists.gnu.org/mailman/listinfo/summer-of-code",
+        "label": "summer-of-code list subscription/archive"
+      },
+      {
+        "type": "Mailing list",
+        "url": "mailto:gnucobol-dev@gnu.org",
+        "label": "gnucobol-dev@gnu.org — GnuCOBOL sub-project"
+      },
+      {
+        "type": "Mailing list",
+        "url": "mailto:bug-aris@gnu.org",
+        "label": "bug-aris@gnu.org — GNU Aris sub-project"
+      },
+      {
+        "type": "Mailing list",
+        "url": "mailto:libcdio-devel@gnu.org",
+        "label": "libcdio-devel@gnu.org — Libcdio sub-project"
       }
     ],
-    "tip": "Send a short intro email with your background and the idea you're interested in.",
+    "tip": "Email summer-of-code@gnu.org to introduce yourself. Sub-project contacts: GnuCOBOL → gnucobol-dev@gnu.org; GNU Aris → bug-aris@gnu.org; Libcdio → libcdio-devel@gnu.org; GNU XaoS → github.com/xaos-project; GNU Boot → git.savannah.gnu.org/cgit/gnuboot.git.",
     "status": "ok",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "lastFetched": "2026-06-02T00:00:00.000Z"
   },
   "GNU Radio": {
     "org": "GNU Radio",


### PR DESCRIPTION
**Program**
GSSoC (program: gssoc)

## Description

Manually researched and verified mentor contact info for GNU Project (GSoC 2026).

- Added 6 mentors with verified GitHub handles sourced from accepted GSoC 2026 projects (via planet.gnu.org and individual project pages):
  - Zoltán Kovács / `kovzol` (GNU XaoS, GNU Aris)
  - Simon Sobisch / `GitMensch` (GnuCOBOL)
  - Nicolas Berthier / `nberth` (GnuCOBOL)
  - Rocky Bernstein / `rocky` (libcdio)
  - Sean O'Brien (GNU Boot — no GitHub, project on Savannah)
  - Adrien Bourmault / neox (GNU Boot - no GitHub, project on Savannah)
- Replaced single generic mailing list entry with 5 targeted entries: umbrella `summer-of-code@gnu.org` + per-sub-project lists (`gnucobol-dev`, `bug-aris`, `libcdio-devel`)
- Updated `tip` with actionable sub-project contact routes (XaoS, GNU Boot, etc.)
- Updated `lastFetched` to `2026-06-02`
- Confirmed `status: ok`

## Related Issue

Closes #308

## Type of Change

- [x] 🐛 Bug fix / data correction

## How to Test

1. Open `data/mentors.json`
2. Find the `"GNU Project"` entry
3. Verify `mentors`, `mailingLists`, `tip`, and `status` fields are populated correctly

## Screenshots (if applicable)

N/A - data-only change

## Checklist

- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)