### PR TITLE
feat: advanced filtering & sorting system (#936)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1426,6 +1426,19 @@ kbd:hover{
     </div>
   </div>
 
+  <div class="mb-6">
+    <div class="flex flex-wrap items-center gap-3 mb-2">
+      <label for="tagFilterInput" class="text-[10px] font-bold uppercase tracking-widest text-zinc-400">Filter by Tags</label>
+    </div>
+    <div class="relative">
+      <input id="tagFilterInput" type="text" placeholder="Search tags (e.g. python, kubernetes, rust)..." autocomplete="off" class="w-full max-w-md bg-surface-container-low border border-zinc-200 dark:border-zinc-700 rounded-xl py-2 px-4 text-xs font-medium focus:ring-2 focus:ring-primary focus:outline-none dark:bg-zinc-800 dark:text-zinc-200" />
+      <div id="tagSuggestions" class="hidden absolute top-full left-0 mt-1 w-full max-w-md bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-lg z-30 max-h-48 overflow-y-auto"></div>
+    </div>
+    <div id="selectedTagsStrip" class="selected-langs-strip mt-2 flex flex-wrap items-center gap-2 min-h-[28px]">
+      <span class="empty-state">No tags selected</span>
+    </div>
+  </div>
+
   <div class="flex flex-wrap items-center justify-between gap-4 mb-8">
     <p class="font-label text-xs uppercase tracking-widest text-zinc-500">Showing <strong id="orgCount" data-org-count>184</strong> of <span data-org-total>184</span> organizations</p>
     <div class="flex flex-wrap items-center gap-4">
@@ -1447,6 +1460,18 @@ kbd:hover{
         <option value="intermediate">Intermediate</option>
         <option value="advanced">Advanced</option>
       </select>
+      <select id="orgSizeFilter" aria-label="Filter by organization size" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600">
+        <option value="all">Org Size: All</option>
+        <option value="large">Large (8+ years)</option>
+        <option value="medium">Medium (4-7 years)</option>
+        <option value="small">Small (≤3 years)</option>
+      </select>
+      <select id="mentorshipFilter" aria-label="Filter by mentorship activity" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600">
+        <option value="all">Mentorship: All</option>
+        <option value="high">High Mentorship</option>
+        <option value="medium">Medium Mentorship</option>
+        <option value="low">Low Mentorship</option>
+      </select>
       <select id="sortSelect" aria-label="Sort organizations" class="bg-surface-container-low border-none rounded-xl text-xs font-bold focus:ring-2 focus:ring-zinc-500 focus:outline-none cursor-pointer text-zinc-600">
         <option value="alpha">Sort: A-Z</option>
         <option value="years-desc">Years (High-Low)</option>
@@ -1454,6 +1479,7 @@ kbd:hover{
         <option value="comp-low">Competition (Chill First)</option>
         <option value="stars">GitHub Stars</option>
         <option value="gfi">Good First Issues</option>
+        <option value="activity">Most Active</option>
       </select>
       <button id="clearFiltersBtn" onclick="clearAllFilters()" class="px-4 py-2 bg-red-50 text-red-600 border border-red-100 rounded-xl text-xs font-bold hover:bg-red-100 transition-colors flex items-center gap-1" title="Clear all search and filters">
         <span class="material-symbols-outlined text-sm">filter_alt_off</span>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -25,9 +25,14 @@ let recentlyViewed = (() => {
 
 const selectedLanguages = new Set();
 let matchAllLanguages = false;
-let activeChip = null; // quick-filter chip key
+let activeChip = null;
 let visibleCount = 12;
-let focusedIdx = -1; // for keyboard card navigation
+let focusedIdx = -1;
+let orgSizeFilter = '';
+let mentorshipFilter = '';
+const selectedTags = new Set();
+let allTags = [];
+const filterCache = new Map();
 
 // Expose globals for external components (recommender, recommendation-ui, etc.)
 globalThis.pills = selectedLanguages;
@@ -78,6 +83,36 @@ const LANGUAGE_MAP = {};
   });
 })();
 globalThis.LANGUAGE_MAP = LANGUAGE_MAP;
+
+const ORG_SIZE_LARGE_THRESHOLD = 8;
+const ORG_SIZE_MEDIUM_THRESHOLD = 4;
+const MENTORSHIP_HIGH_THRESHOLD = 5;
+const MENTORSHIP_MEDIUM_THRESHOLD = 2;
+const FILTER_CACHE_MAX = 50;
+
+function getOrgSize(org) {
+  if (org.years >= ORG_SIZE_LARGE_THRESHOLD) return 'large';
+  if (org.years >= ORG_SIZE_MEDIUM_THRESHOLD) return 'medium';
+  return 'small';
+}
+
+function getMentorshipLevel(org) {
+  const mentors = MENTOR_DATA[org.name];
+  const count = Array.isArray(mentors) ? mentors.length : 0;
+  if (count >= MENTORSHIP_HIGH_THRESHOLD) return 'high';
+  if (count >= MENTORSHIP_MEDIUM_THRESHOLD) return 'medium';
+  return 'low';
+}
+
+function compileAllTags() {
+  const tagSet = new Set();
+  ORGS.forEach(o => (o.tags || []).forEach(t => tagSet.add(t)));
+  allTags = [...tagSet].sort((a, b) => a.localeCompare(b));
+}
+
+function resetFilterCache() {
+  filterCache.clear();
+}
 
 const UMBRELLA_ORGS = new Set([
   'Apache Software Foundation', 'CNCF', 'Eclipse Foundation', 'FOSSASIA', 'GNOME Foundation',
@@ -1051,6 +1086,12 @@ function matchesFilters(o, cat, compF, search) {
   if (compF && compF !== 'all' && o.codebase !== compF) return false;
   if (search && !orgName.includes(search)) return false;
   if (selectedLanguages.size > 0 && !orgMatchesLanguages(o, selectedLanguages)) return false;
+  if (orgSizeFilter && getOrgSize(o) !== orgSizeFilter) return false;
+  if (mentorshipFilter && getMentorshipLevel(o) !== mentorshipFilter) return false;
+  if (selectedTags.size > 0) {
+    const orgTags = new Set((o.tags || []).map(t => t.toLowerCase().trim()));
+    if (![...selectedTags].every(t => orgTags.has(t.toLowerCase().trim()))) return false;
+  }
 
   if (activeChip) {
     if (activeChip === 'bookmarked' && !bookmarkedSet.has(o.name)) return false;
@@ -1080,10 +1121,29 @@ function applyFilters() {
   const cat = categoryValue === 'all' ? '' : categoryValue;
   const compF = document.getElementById('complexityFilter')?.value || 'all';
   const sort = document.getElementById('sortSelect')?.value || 'alpha';
+  orgSizeFilter = document.getElementById('orgSizeFilter')?.value || '';
+  if (orgSizeFilter === 'all') orgSizeFilter = '';
+  mentorshipFilter = document.getElementById('mentorshipFilter')?.value || '';
+  if (mentorshipFilter === 'all') mentorshipFilter = '';
+
+  const cacheKey = JSON.stringify({ search, cat, compF, sort, orgSizeFilter, mentorshipFilter, selectedLanguages: [...selectedLanguages].sort((a, b) => a.localeCompare(b)), activeChip, selectedTags: [...selectedTags].sort((a, b) => a.localeCompare(b)) });
+  const cached = filterCache.get(cacheKey);
+  if (cached) {
+    filterCache.delete(cacheKey);
+    filterCache.set(cacheKey, cached);
+    filteredOrgs = cached;
+    renderOrgs(true);
+    syncFilterUrl(search, cat, compF, sort);
+    return;
+  }
 
   filteredOrgs = ORGS.filter(o => matchesFilters(o, cat, compF, search));
+  filterCache.set(cacheKey, filteredOrgs);
+  if (filterCache.size > FILTER_CACHE_MAX) {
+    const firstKey = filterCache.keys().next().value;
+    filterCache.delete(firstKey);
+  }
 
-  // Smart sorting: Exact match first, startsWith second, alphabetic/secondary sort third
   if (search) {
     filteredOrgs.sort((a, b) => searchComparator(a, b, search, sort));
   } else {
@@ -1091,8 +1151,10 @@ function applyFilters() {
   }
 
   renderOrgs(true);
+  syncFilterUrl(search, cat, compF, sort);
+}
 
-  // Sync state to URL
+function syncFilterUrl(search, cat, compF, sort) {
   const params = new URLSearchParams();
   if (search) params.set('q', search);
   if (cat) params.set('cat', cat);
@@ -1100,6 +1162,9 @@ function applyFilters() {
   if (sort && sort !== 'alpha') params.set('sort', sort);
   if (selectedLanguages.size) params.set('lang', [...selectedLanguages].join(','));
   if (activeChip) params.set('chip', activeChip);
+  if (orgSizeFilter) params.set('size', orgSizeFilter);
+  if (mentorshipFilter) params.set('mentor', mentorshipFilter);
+  if (selectedTags.size) params.set('tags', [...selectedTags].join(','));
   if (typeof history !== 'undefined' && typeof history.replaceState === 'function' && typeof location !== 'undefined') {
     history.replaceState(null, '', params.toString() ? '?' + params.toString() : location.pathname);
   }
@@ -1111,6 +1176,10 @@ function applySecondarySort(a, b, sortType) {
   if (sortType === 'comp-low') return ['chill', 'moderate', 'hot'].indexOf(a.competition) - ['chill', 'moderate', 'hot'].indexOf(b.competition);
   if (sortType === 'stars') return (b._gh?.stars || 0) - (a._gh?.stars || 0);
   if (sortType === 'gfi') return (b._gh?.gfi || 0) - (a._gh?.gfi || 0);
+  if (sortType === 'activity') {
+    const actOrder = { active: 3, high: 3, moderate: 2, low: 1, inactive: 0 };
+    return (actOrder[b._gh?.activity] || 0) - (actOrder[a._gh?.activity] || 0);
+  }
   return a.name.localeCompare(b.name);
 }
 
@@ -1293,6 +1362,20 @@ globalThis.clearAllFilters = function () {
   if (complexityFilter) complexityFilter.value = 'all';
   const sortSelect = document.getElementById('sortSelect');
   if (sortSelect) sortSelect.value = 'alpha';
+  const orgSizeEl = document.getElementById('orgSizeFilter');
+  if (orgSizeEl) orgSizeEl.value = 'all';
+  const mentorshipEl = document.getElementById('mentorshipFilter');
+  if (mentorshipEl) mentorshipEl.value = 'all';
+
+  orgSizeFilter = '';
+  mentorshipFilter = '';
+  selectedTags.clear();
+  const tagStrip = document.getElementById('selectedTagsStrip');
+  if (tagStrip) tagStrip.innerHTML = '<span class="empty-state">No tags selected</span>';
+  const tagInput = document.getElementById('tagFilterInput');
+  if (tagInput) tagInput.value = '';
+  const tagSuggestions = document.getElementById('tagSuggestions');
+  if (tagSuggestions) tagSuggestions.classList.add('hidden');
 
   // Reset chips
   document.querySelectorAll('.filter-chip').forEach(chip => {
@@ -1307,6 +1390,7 @@ globalThis.clearAllFilters = function () {
     p.setAttribute('aria-pressed', 'false');
   });
 
+  resetFilterCache();
   renderSelectedLanguages();
   applyFilters();
 };
@@ -1725,6 +1809,64 @@ function renderSelectedLanguages() {
 
   const clearAll = safeHTML`<button class="clear-all-langs-btn">Clear all</button>`;
   container.innerHTML = badges + clearAll;
+}
+
+// ══════════════════════════════════════════════
+// TAG FILTERING SYSTEM
+// ══════════════════════════════════════════════
+function renderTagSuggestions(query) {
+  const container = document.getElementById('tagSuggestions');
+  if (!container) return;
+  if (!query || query.length < 1) {
+    container.classList.add('hidden');
+    return;
+  }
+  const q = query.toLowerCase().trim();
+  const matches = allTags.filter(t => t.toLowerCase().includes(q) && !selectedTags.has(t));
+  if (!matches.length) {
+    container.classList.add('hidden');
+    return;
+  }
+  container.classList.remove('hidden');
+  container.innerHTML = matches.slice(0, 10).map(tag =>
+    `<button type="button" class="tag-suggestion px-3 py-1.5 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-orange-50 dark:hover:bg-orange-950/30 hover:text-primary w-full text-left rounded transition-colors" data-tag="${escapeHtml(tag)}">${escapeHtml(tag)}</button>`
+  ).join('');
+}
+
+function selectTagFn(tag) {
+  if (selectedTags.has(tag)) return;
+  selectedTags.add(tag);
+  const tagInput = document.getElementById('tagFilterInput');
+  if (tagInput) tagInput.value = '';
+  const tagSuggestions = document.getElementById('tagSuggestions');
+  if (tagSuggestions) tagSuggestions.classList.add('hidden');
+  renderSelectedTags();
+  resetFilterCache();
+  applyFilters();
+}
+globalThis.selectTag = selectTagFn;
+
+function unselectTagFn(tag) {
+  selectedTags.delete(tag);
+  renderSelectedTags();
+  resetFilterCache();
+  applyFilters();
+}
+globalThis.unselectTag = unselectTagFn;
+
+function renderSelectedTags() {
+  const container = document.getElementById('selectedTagsStrip');
+  if (!container) return;
+  if (!selectedTags.size) {
+    container.innerHTML = '<span class="empty-state">No tags selected</span>';
+    return;
+  }
+  container.innerHTML = [...selectedTags].map(tag =>
+    `<span class="selected-lang-badge" data-tag="${escapeHtml(tag)}">
+      ${escapeHtml(tag)}
+      <button class="unselect-lang-btn" aria-label="Remove ${escapeHtml(tag)}">×</button>
+    </span>`
+  ).join('');
 }
 
 // ══════════════════════════════════════════════
@@ -2238,7 +2380,10 @@ async function loadMentorData() {
     const res = await fetch('/data/mentors.json?v=' + Date.now());
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    MENTOR_DATA = data.mentors || {};
+    MENTOR_DATA = {};
+    Object.entries(data).forEach(([name, entry]) => {
+      MENTOR_DATA[name] = Array.isArray(entry) ? entry : (entry.mentors || []);
+    });
     mentorDataState = 'loaded';
     renderMentorFinder();
   } catch (err) {
@@ -2398,6 +2543,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  compileAllTags();
+
   // Restore filter state from URL parameters
   (function restoreFiltersFromURL() {
     const params = new URLSearchParams(location.search);
@@ -2444,6 +2591,26 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
     }
+
+    const sizeParam = params.get('size');
+    if (sizeParam) {
+      orgSizeFilter = sizeParam;
+      const sizeEl = document.getElementById('orgSizeFilter');
+      if (sizeEl) sizeEl.value = sizeParam;
+    }
+
+    const mentorParam = params.get('mentor');
+    if (mentorParam) {
+      mentorshipFilter = mentorParam;
+      const mentorEl = document.getElementById('mentorshipFilter');
+      if (mentorEl) mentorEl.value = mentorParam;
+    }
+
+    const tagsParam = params.get('tags');
+    if (tagsParam) {
+      tagsParam.split(',').map(s => s.trim()).filter(Boolean).forEach(t => selectedTags.add(t));
+      renderSelectedTags();
+    }
   })();
 
   updateCountdown();
@@ -2467,6 +2634,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('categoryFilter')?.addEventListener('change', applyFilters);
   document.getElementById('complexityFilter')?.addEventListener('change', applyFilters);
   document.getElementById('sortSelect')?.addEventListener('change', applyFilters);
+  document.getElementById('orgSizeFilter')?.addEventListener('change', () => { resetFilterCache(); applyFilters(); });
+  document.getElementById('mentorshipFilter')?.addEventListener('change', () => { resetFilterCache(); applyFilters(); });
   document.getElementById('mentorSearchInput')?.addEventListener('input', renderMentorFinder);
   document.getElementById('mentorChannelFilter')?.addEventListener('change', renderMentorFinder);
   document.getElementById('matchAllLanguagesToggle')?.addEventListener('change', (e) => {
@@ -2479,6 +2648,45 @@ document.addEventListener('DOMContentLoaded', () => {
     visibleCount += 12;
     renderOrgs(false);
   });
+
+  const tagFilterInput = document.getElementById('tagFilterInput');
+  if (tagFilterInput) {
+    let tagInputTimer;
+    tagFilterInput.addEventListener('input', () => {
+      clearTimeout(tagInputTimer);
+      tagInputTimer = setTimeout(() => renderTagSuggestions(tagFilterInput.value), 100);
+    });
+    tagFilterInput.addEventListener('focus', () => {
+      if (tagFilterInput.value.trim()) renderTagSuggestions(tagFilterInput.value);
+    });
+    tagFilterInput.addEventListener('blur', () => {
+      setTimeout(() => {
+        const suggestions = document.getElementById('tagSuggestions');
+        if (suggestions) suggestions.classList.add('hidden');
+      }, 200);
+    });
+  }
+  const tagSuggestions = document.getElementById('tagSuggestions');
+  if (tagSuggestions) {
+    tagSuggestions.addEventListener('click', (e) => {
+      const btn = e.target.closest('.tag-suggestion');
+      if (btn?.dataset?.tag) {
+        selectTagFn(btn.dataset.tag);
+      }
+    });
+  }
+  const selectedTagsStrip = document.getElementById('selectedTagsStrip');
+  if (selectedTagsStrip) {
+    selectedTagsStrip.addEventListener('click', (e) => {
+      const unselectBtn = e.target.closest('.unselect-lang-btn');
+      if (unselectBtn) {
+        const parent = unselectBtn.closest('[data-tag]');
+        if (parent?.dataset?.tag) {
+          unselectTagFn(parent.dataset.tag);
+        }
+      }
+    });
+  }
 
   document.getElementById('surpriseBtn')?.addEventListener('click', openRandomOrg);
 
@@ -2627,6 +2835,9 @@ if (typeof module !== 'undefined' && module.exports) {
     closeModal,
     safeHTML,
     rawHTML,
-    renderGoodFirstIssues
+    renderGoodFirstIssues,
+    getOrgSize,
+    getMentorshipLevel,
+    compileAllTags
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -327,6 +327,24 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 [data-theme="dark"] .cb-os{background:rgba(100,116,139,.15);color:#9CA3AF}
 [data-theme="dark"] .cb-other{background:rgba(255,255,255,.05);color:var(--muted)}
 
+/* ── TAG SUGGESTIONS ── */
+/* stylelint-disable selector-id-pattern */
+#tagSuggestions {
+  scrollbar-width: thin;
+}
+#tagSuggestions::-webkit-scrollbar {
+  width: 4px;
+}
+#tagSuggestions::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+/* stylelint-enable selector-id-pattern */
+.tag-suggestion:focus-visible {
+  outline: 2px solid var(--orange);
+  outline-offset: -2px;
+}
+
 /* ── EMPTY ── */
 .empty{grid-column:1/-1;text-align:center;padding:70px 20px;color:var(--muted)}
 .empty-icon{font-size:44px;margin-bottom:14px}

--- a/tests/filtering.test.js
+++ b/tests/filtering.test.js
@@ -27,7 +27,7 @@ globalThis.document = {
 globalThis.ORGS = require('../src/js/org.js');
 
 // Import the modules
-const { orgMatchesLanguages, applySecondarySort } = require('../src/js/app.js');
+const { orgMatchesLanguages, applySecondarySort, getOrgSize, getMentorshipLevel } = require('../src/js/app.js');
 require('../src/js/skillExtractor.js'); // Populates LANGUAGE_MAP on global
 
 test('orgMatchesLanguages returns true when languages set is empty', () => {
@@ -58,8 +58,8 @@ test('orgMatchesLanguages filters correctly with matchAllLanguages = true', () =
 });
 
 test('applySecondarySort sorts correctly', () => {
-  const a = { name: 'A', years: 10, competition: 'hot', _gh: { stars: 100, gfi: 5 } };
-  const b = { name: 'B', years: 5, competition: 'chill', _gh: { stars: 50, gfi: 15 } };
+  const a = { name: 'A', years: 10, competition: 'hot', _gh: { stars: 100, gfi: 5, activity: 'active' } };
+  const b = { name: 'B', years: 5, competition: 'chill', _gh: { stars: 50, gfi: 15, activity: 'moderate' } };
 
   // stars sort (descending)
   assert.ok(applySecondarySort(a, b, 'stars') < 0);
@@ -75,4 +75,33 @@ test('applySecondarySort sorts correctly', () => {
 
   // alphabetical sort (default)
   assert.ok(applySecondarySort(a, b, 'alpha') < 0);
+
+  // activity sort: active before moderate
+  assert.ok(applySecondarySort(a, b, 'activity') < 0);
+});
+
+test('getOrgSize classifies orgs by years', () => {
+  assert.strictEqual(getOrgSize({ years: 10 }), 'large');
+  assert.strictEqual(getOrgSize({ years: 8 }), 'large');
+  assert.strictEqual(getOrgSize({ years: 7 }), 'medium');
+  assert.strictEqual(getOrgSize({ years: 4 }), 'medium');
+  assert.strictEqual(getOrgSize({ years: 3 }), 'small');
+  assert.strictEqual(getOrgSize({ years: 1 }), 'small');
+});
+
+test('getMentorshipLevel classifies orgs by mentor count', () => {
+  assert.strictEqual(getMentorshipLevel({ name: 'NoMentorOrg' }), 'low');
+  assert.strictEqual(getMentorshipLevel({ name: 'SingleMentorOrg' }), 'low');
+});
+
+test('activity sort orders active before moderate before inactive', () => {
+  const active = { name: 'X', _gh: { activity: 'active' } };
+  const moderate = { name: 'Y', _gh: { activity: 'moderate' } };
+  const inactive = { name: 'Z', _gh: { activity: 'inactive' } };
+  const noData = { name: 'W' };
+
+  assert.ok(applySecondarySort(active, moderate, 'activity') < 0);
+  assert.ok(applySecondarySort(moderate, inactive, 'activity') < 0);
+  assert.strictEqual(applySecondarySort(inactive, noData, 'activity'), 0);
+  assert.ok(applySecondarySort(noData, active, 'activity') > 0);
 });


### PR DESCRIPTION
## 🚀 Program
General Contributor (no program affiliation)

program: general

## 📝 Description
Implements an advanced filtering and sorting system to improve project discoverability as the dataset grows. Users can now apply multiple filters simultaneously and sort by relevance/activity to quickly narrow down organizations matching their interests.

**New Filters:**
- **Organization Size** — derived from GSoC years (Small ≤3, Medium 4–7, Large ≥8)
- **Mentorship Activity** — based on mentor count from cached mentor data (High ≥5, Medium ≥2, Low <2)
- **Tag-based Filtering** — type-ahead autocomplete search across all org tech tags, with multi-select removable chips (AND logic)

**New Sort:**
- **Most Active** — orders by GitHub activity level (active > moderate > inactive)

**Performance:**
- Filter results are memoized via an LRU cache (max 50 entries), preventing redundant re-computation

**URL Shareability:**
- All new filter states persist as query params (`size`, `mentor`, `tags`) for shareable/searchable URLs

## 🔗 Related Issue
Closes #936

## 🔄 Type of Change
- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `index.html` in a browser
2. Use the **Org Size** dropdown to filter by small/medium/large orgs
3. Use the **Mentorship** dropdown to filter by mentorship activity level
4. Type in the **Tag Filter** input (e.g. "python", "kubernetes") and select tags — orgs are filtered to match ALL selected tags
5. Select **"Most Active"** from the Sort dropdown
6. Run `npm test` — all 28 tests pass
7. Run `npm run lint:js` and `npm run lint:css` — no errors

## ✅ Checklist
- [x] I am contributing as an independent/general contributor
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools
