### PR TITLE
fix(data): verify Apache Software Foundation mentor contacts

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -136,13 +136,29 @@
   "Apache Software Foundation": {
     "org": "Apache Software Foundation",
     "ideasUrl": "https://community.apache.org/gsoc.html",
-    "channels": [],
+    "channels": [
+      {
+        "type": "Mailing list",
+        "url": "https://lists.apache.org/list.html?dev@community.apache.org",
+        "label": "dev@community.apache.org"
+      },
+      {
+        "type": "Mailing list",
+        "url": "https://lists.apache.org/list.html?mentors@community.apache.org",
+        "label": "mentors@community.apache.org"
+      }
+    ],
     "mentors": [],
     "mailingLists": [
       {
         "type": "Mailing list",
-        "url": "https://groups.google.com/group/google-summer-of-code-discuss",
-        "label": "GSoC discussion list"
+        "url": "https://lists.apache.org/list.html?dev@community.apache.org",
+        "label": "dev@community.apache.org"
+      },
+      {
+        "type": "Mailing list",
+        "url": "https://lists.apache.org/list.html?mentors@community.apache.org",
+        "label": "mentors@community.apache.org"
       }
     ],
     "tip": "Send a short intro email with your background and the idea you're interested in.",


### PR DESCRIPTION
Program: GSSOC
## Summary

Verified and updated Apache Software Foundation mentor contact information for GSoC 2026.

### Changes made

* Verified the Apache Software Foundation ideas page URL
* Added Apache community mailing lists as communication channels
* Updated mailing list information with verified Apache mailing lists
* Kept status as "ok"
* Left mentors list empty because Apache Software Foundation is an umbrella organization and does not provide a single top-level mentor list

Closes #259
