### PR TITLE
feat: add visual click feedback for scroll navigation buttons (#1791)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1001,6 +1001,7 @@ kbd:hover{
   box-shadow: 0 4px 12px rgba(157, 67, 0, 0.2);
   filter: brightness(0.95);
 }
+
     #nextSectionBtn { bottom: calc(var(--section-fab-bottom) + env(safe-area-inset-bottom)); }
     #prevSectionBtn {
       bottom: calc(var(--section-fab-bottom) + var(--section-fab-size) + var(--section-fab-gap) + env(safe-area-inset-bottom));

--- a/index.html
+++ b/index.html
@@ -1000,6 +1000,7 @@ kbd:hover{
   transform: translateY(1px) scale(0.92);
   box-shadow: 0 4px 12px rgba(157, 67, 0, 0.2);
   filter: brightness(0.95);
+  transition: all 0.1s ease;
 }
 
     #nextSectionBtn { bottom: calc(var(--section-fab-bottom) + env(safe-area-inset-bottom)); }
@@ -1019,6 +1020,7 @@ kbd:hover{
   transform: translateY(1px) scale(0.92);
   box-shadow: 0 4px 12px rgba(194, 65, 12, 0.2);
   filter: brightness(0.95);
+  transition: all 0.1s ease;
 }
 
 /* Dark mode - Section scroll indicator */


### PR DESCRIPTION
Closes #1791. Adds active click visual feedback to the scroll buttons (#prevSectionBtn and #nextSectionBtn) for light and dark modes.