### PR TITLE
fix(ui): resolve dark mode text contrast on category badges and fix python label symbol layout (#911)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -36,17 +36,17 @@ globalThis.compareList = compareList;
 globalThis.bookmarkedSet = bookmarkedSet;
 
 const CATEGORY_META = {
-  science: { className: 'bg-blue-100 text-blue-700', label: 'Science' },
-  programming: { className: 'bg-violet-100 text-violet-700', label: 'Programming' },
-  data: { className: 'bg-cyan-100 text-cyan-700', label: 'Data' },
-  web: { className: 'bg-green-100 text-green-700', label: 'Web' },
-  os: { className: 'bg-orange-100 text-orange-700', label: 'OS / Systems' },
-  security: { className: 'bg-red-100 text-red-700', label: 'Security' },
-  media: { className: 'bg-pink-100 text-pink-700', label: 'Media' },
-  infra: { className: 'bg-yellow-100 text-yellow-700', label: 'Infrastructure' },
-  ai: { className: 'bg-purple-100 text-purple-700', label: 'AI / ML' },
-  dev: { className: 'bg-teal-100 text-teal-700', label: 'Dev Tools' },
-  other: { className: 'bg-zinc-100 text-zinc-600', label: 'Other' },
+  science: { className: 'bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300', label: 'Science' },
+  programming: { className: 'bg-violet-100 text-violet-700 dark:bg-violet-950/50 dark:text-violet-300', label: 'Programming' },
+  data: { className: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-950/50 dark:text-cyan-300', label: 'Data' },
+  web: { className: 'bg-green-100 text-green-700 dark:bg-green-950/50 dark:text-green-300', label: 'Web' },
+  os: { className: 'bg-orange-100 text-orange-700 dark:bg-orange-950/50 dark:text-orange-300', label: 'OS / Systems' },
+  security: { className: 'bg-red-100 text-red-700 dark:bg-red-950/50 dark:text-red-300', label: 'Security' },
+  media: { className: 'bg-pink-100 text-pink-700 dark:bg-pink-950/50 dark:text-pink-300', label: 'Media' },
+  infra: { className: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-950/50 dark:text-yellow-300', label: 'Infrastructure' },
+  ai: { className: 'bg-purple-100 text-purple-700 dark:bg-purple-950/50 dark:text-purple-300', label: 'AI / ML' },
+  dev: { className: 'bg-teal-100 text-teal-700 dark:bg-teal-950/50 dark:text-teal-300', label: 'Dev Tools' },
+  other: { className: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300', label: 'Other' },
 };
 
 const LANGUAGE_ALIASES = {
@@ -1154,7 +1154,11 @@ function renderOrgs(reset = true) {
       ? safeHTML`<img src="${logoUrl}" data-org-name="${org.name}" alt="${org.name} logo" class="w-full h-full object-contain rounded-lg" />`
       : safeHTML`<div class="logo-placeholder flex w-full h-full items-center justify-center text-primary font-bold text-xl bg-primary/5">${(org.name || '?')[0].toUpperCase()}</div>`;
 
-    const tagsHtml = org.tags.slice(0, 3).map(t => safeHTML`<span class="px-2 py-0.5 bg-surface-container-low dark:bg-zinc-800 text-[10px] font-mono rounded text-zinc-600 dark:text-zinc-400">${t}</span>`);
+    const tagsHtml = org.tags.slice(0, 3).map(t => {
+  // If the tag is python, prefix it with a clean visual snake symbol identifier matching layout expectations
+  const displayTag = t.trim().toLowerCase() === 'python' ? '🐍 python' : t;
+  return safeHTML`<span class="px-2 py-0.5 bg-surface-container-low dark:bg-zinc-800 text-[10px] font-mono rounded text-zinc-600 dark:text-zinc-400">${displayTag}</span>`;
+});
     const moreTagsHtml = org.tags.length > 3 ? safeHTML`<span class="px-2 py-0.5 bg-surface-container-low dark:bg-zinc-800 text-[10px] font-mono rounded text-zinc-600 dark:text-zinc-400 cursor-help" title="${org.tags.slice(3).join(', ')}">+${String(org.tags.length - 3)}</span>` : '';
 
     const catLabel = getCategoryMeta(org.cat).label.toUpperCase();


### PR DESCRIPTION
program: gssoc

### Description
- **Text Contrast Inconsistency:** Category text markers on organization overview directories used explicit static properties (e.g., `text-blue-700`), causing text labels to blur or wash out invisibly when the dark theme configuration modifier (`.dark`) was toggled on the document workspace.
- **Python Visual Missing Asset:** The text card rendering module processed technology arrays as direct lowercase string fields inside standard layout tags, lacking matching unified symbol character prefixes.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX Improvement

### Proposed Solution Details
- **Enhanced Dark Mode Contrast:** Optimized the core utility `CATEGORY_META` lookup layout matrix within `src/js/app.js` to systematically inherit explicit accessibility standard tailwind theme adjustments (`dark:bg-blue-950/50`, `dark:text-blue-300`, etc.) ensuring crisp, high-contrast readability across light and dark templates.
- **Unified Visual Labeling:** Refactored the inline technology tag layout rendering pipelines inside `renderOrgs` to check for core language string identities dynamically, mapping an appropriate visual text symbol identifier (`🐍 python`) matching standard platform expectations.

### Related Issue
Closes #911

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Verified high-contrast visibility locally under theme state switches.