### PR TITLE
Fix keyboard focus trap for organization modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -3953,8 +3953,15 @@ let previousFocusedElement = null;
   document.body.style.overflow = '';
 
   if (previousFocusedElement) {
+  if (
+    previousFocusedElement.isConnected &&
+    previousFocusedElement.offsetParent !== null
+  ) {
     previousFocusedElement.focus();
   }
+
+  previousFocusedElement = null;
+}
 }
 
   function openRandomOrg() {

--- a/index.html
+++ b/index.html
@@ -3935,6 +3935,8 @@ if(org.ideas){
      
    const modal = document.getElementById('orgModal');
 
+previousFocusedElement = document.activeElement;
+
 modal.classList.add('open');
 modal.setAttribute('tabindex', '-1');
 modal.focus();
@@ -3943,13 +3945,17 @@ document.body.classList.add('modal-open');
 document.documentElement.style.overflow = 'hidden';
 document.body.style.overflow = 'hidden';
   }
-
+let previousFocusedElement = null;
   function closeOrgModal() {
-    document.getElementById('orgModal').classList.remove('open');
-    document.body.classList.remove('modal-open');
-    document.documentElement.style.overflow = '';
-    document.body.style.overflow = '';
+  document.getElementById('orgModal').classList.remove('open');
+  document.body.classList.remove('modal-open');
+  document.documentElement.style.overflow = '';
+  document.body.style.overflow = '';
+
+  if (previousFocusedElement) {
+    previousFocusedElement.focus();
   }
+}
 
   function openRandomOrg() {
     const orgsToUse = filteredOrgs.length > 0 ? filteredOrgs : ORGS;

--- a/index.html
+++ b/index.html
@@ -3933,13 +3933,15 @@ if(org.ideas){
       draftBtn.onclick = () => ProposalBuilder.open(org.name);
     }
      
-    const modal = document.getElementById('orgModal');
+   const modal = document.getElementById('orgModal');
 
 modal.classList.add('open');
 modal.setAttribute('tabindex', '-1');
 modal.focus();
 
 document.body.classList.add('modal-open');
+document.documentElement.style.overflow = 'hidden';
+document.body.style.overflow = 'hidden';
   }
 
   function closeOrgModal() {

--- a/index.html
+++ b/index.html
@@ -3408,6 +3408,35 @@ btn.__orgListenerAttached = true;
       closeAn();
     }
   });
+  document.getElementById('orgModal')?.addEventListener('keydown', (e) => {
+  if (
+    e.key !== 'Tab' ||
+    !document.getElementById('orgModal')?.classList.contains('open')
+  ) return;
+
+  const modal = document.getElementById('orgModal');
+
+  const focusable = modal.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+
+  const list = [...focusable].filter(
+    (el) => !el.disabled && el.offsetParent !== null
+  );
+
+  if (list.length === 0) return;
+
+  const first = list[0];
+  const last = list[list.length - 1];
+
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+});
   
 
   function applyFiltersPreservingVisibleCount() {
@@ -3904,10 +3933,13 @@ if(org.ideas){
       draftBtn.onclick = () => ProposalBuilder.open(org.name);
     }
      
-    document.getElementById('orgModal').classList.add('open');
-    document.body.classList.add('modal-open');
-    document.documentElement.style.overflow = 'hidden';
-    document.body.style.overflow = 'hidden';
+    const modal = document.getElementById('orgModal');
+
+modal.classList.add('open');
+modal.setAttribute('tabindex', '-1');
+modal.focus();
+
+document.body.classList.add('modal-open');
   }
 
   function closeOrgModal() {


### PR DESCRIPTION
**Description**
Improved keyboard accessibility for the organization details modal by ensuring focus remains trapped within the modal during keyboard navigation.

**Changes Made**

* Added keyboard focus trapping for `orgModal` using `Tab` and `Shift + Tab` navigation
* Ensured focus cycles only within the organization modal while open
* Added focus handling when opening the modal (`tabindex` + `focus()`)
* Preserved existing `Escape` key behavior for closing the modal
* Improved accessibility for keyboard-only users

**Related Issue**
Fixes #1388

program: gssoc

**Type of Change**
Accessibility improvement

**Checklist**
✅ Tested keyboard navigation manually
✅ Verified `Escape` key still closes modal
✅ Verified focus remains inside modal using `Tab` / `Shift + Tab`
✅ Changes are limited to relevant files
✅ No unrelated changes added

