### PR TITLE
fix: keep back-to-top button clear of section controls

### DIFF
--- a/src/js/footer.js
+++ b/src/js/footer.js
@@ -26,13 +26,23 @@ document.addEventListener('DOMContentLoaded', () => {
 function initFooter() {
   const backToTopBtn = document.getElementById('back-to-top-btn');
   if (backToTopBtn) {
-    window.addEventListener('scroll', () => {
-      if (window.scrollY > 300) {
+    const updateBackToTopVisibility = () => {
+      const scrollTop = window.scrollY || window.pageYOffset || 0;
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+      const documentHeight = document.documentElement.scrollHeight || 0;
+      const distanceFromBottom = documentHeight - (scrollTop + viewportHeight);
+      const revealThreshold = Math.max(500, Math.round(viewportHeight * 0.75));
+
+      if (distanceFromBottom <= revealThreshold) {
         backToTopBtn.classList.add('show');
       } else {
         backToTopBtn.classList.remove('show');
       }
-    }, { passive: true });
+    };
+
+    window.addEventListener('scroll', updateBackToTopVisibility, { passive: true });
+    window.addEventListener('resize', updateBackToTopVisibility);
+    updateBackToTopVisibility();
 
     backToTopBtn.addEventListener('click', () => {
       window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/src/styles.css
+++ b/src/styles.css
@@ -528,8 +528,8 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 
 #back-to-top-btn {
   position: fixed;
-  bottom: 24px;
-  right: 24px;
+  bottom: calc(var(--section-fab-bottom) + (var(--section-fab-size) + var(--section-fab-gap)) * 3 + env(safe-area-inset-bottom));
+  right: calc(var(--section-fab-right) + env(safe-area-inset-right));
   width: 44px;
   height: 44px;
   border-radius: 50%;
@@ -913,4 +913,3 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 .privacy-page #back-to-top-btn:focus-visible {
   outline-color: #f97316;
 }
-


### PR DESCRIPTION
## Summary
- delay the back-to-top button until the reader is near the end of the page
- move the button into the same floating-control spacing system as the section nav controls
- keep the control stack from colliding on desktop and mobile layouts

## Validation
- `node --check src/js/footer.js`
- `npm test`
- `git diff --check`

Fixes #1828
