### PR TITLE
fix: tighten timeline hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1335,7 +1335,7 @@ kbd:hover{
             <h3 class="font-headline font-extrabold text-lg sm:text-xl">2026 Timeline</h3>
             <span class="px-3 py-1 bg-green-100 text-green-700 rounded-full text-[10px] font-bold uppercase tracking-wider">Live</span>
           </div>
-          <div id="timeline-milestones" aria-label="GSoC timeline milestones" class="space-y-4 sm:space-y-5 overflow-y-auto max-h-[50vh] pl-4 no-scrollbar focus:outline-none focus:ring-2 focus:ring-primary/30 rounded-lg"></div>
+          <div id="timeline-milestones" aria-label="GSoC timeline milestones" class="space-y-4 sm:space-y-5 overflow-y-auto pl-4 no-scrollbar focus:outline-none focus:ring-2 focus:ring-primary/30 rounded-lg"></div>
           <div class="mt-5 sm:mt-6 pt-5 sm:pt-6 border-t border-zinc-100">
             <div class="flex items-center justify-between">
               <span class="text-xs text-zinc-500" id="countdown-label">Next milestone</span>
@@ -2965,16 +2965,9 @@ kbd:hover{
       }).join('');
       const currentMilestone = container.querySelector('.current-milestone');
       requestAnimationFrame(() => { 
-        if (currentMilestone) {
-        container.scrollTo({
-          top:
-            currentMilestone.offsetTop -
-            container.offsetTop -
-            container.clientHeight / 2 +
-            currentMilestone.clientHeight / 2,
-          behavior: 'smooth'
-        });
-      }
+        if (currentMilestone && typeof currentMilestone.scrollIntoView === 'function') {
+          currentMilestone.scrollIntoView({ block: 'center', behavior: 'smooth', inline: 'nearest' });
+        }
       });
     } catch (err) {
       console.warn('[Timeline] renderTimeline failed:', err);

--- a/src/styles.css
+++ b/src/styles.css
@@ -371,6 +371,10 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 .m-tags{display:flex;flex-wrap:wrap;gap:5px;margin-bottom:16px}
 .m-tag{font-size:11px;padding:4px 10px;border-radius:6px;border:1.5px solid var(--border);color:var(--ink3);background:var(--bg);font-weight:500;transition:background .3s,border-color .3s,color .3s}
 .timeline{font-size:12px;color:var(--ink3);line-height:2;margin-bottom:16px}
+#timeline-milestones{
+  height: clamp(18rem, 42vh, 28rem);
+  scroll-behavior: smooth;
+}
 .modal-cta{display:inline-flex;align-items:center;gap:8px;background:var(--orange);color:white;padding:11px 20px;border-radius:10px;font-size:13px;font-weight:700;text-decoration:none;transition:background .18s}
 .modal-cta:hover{background:var(--orange-deep)}
 .modal-ideas-link{display:inline-flex;align-items:center;gap:8px;background:var(--green);color:white;padding:11px 20px;border-radius:10px;font-size:13px;font-weight:700;text-decoration:none;transition:background .18s;margin-right:10px}
@@ -913,4 +917,3 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 .privacy-page #back-to-top-btn:focus-visible {
   outline-color: #f97316;
 }
-


### PR DESCRIPTION
## Summary
- give the timeline panel a fixed, responsive height so it doesn't swallow the hero
- keep the timeline internally scrollable instead of stretching the page
- center the current milestone on load so the most relevant date is visible immediately

## Validation
- `git diff --check`
- `npm test`

Fixes #1653
