### PR TITLE
fix: add missing mentor contact info for Blender Foundation and Boa

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -399,23 +399,40 @@
   },
   "Blender Foundation": {
     "org": "Blender Foundation",
-    "ideasUrl": "https://developer.blender.org/docs/programs/gsoc/2026",
-    "channels": [],
+    "ideasUrl": "https://developer.blender.org/docs/programs/gsoc/ideas/",
+    "channels": [
+      {
+        "type": "Forum",
+        "url": "https://devtalk.blender.org",
+        "label": "Blender Developer Forum"
+      },
+      {
+        "type": "Chat",
+        "url": "https://chat.blender.org",
+        "label": "Blender Chat"
+      }
+    ],
     "mentors": [],
     "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "tip": "Introduce yourself on the developer forum or chat before asking project-specific questions.",
+    "status": "ok",
+    "lastFetched": "2026-06-12T00:00:00.000Z"
   },
   "Boa": {
     "org": "Boa",
     "ideasUrl": "https://github.com/boa-dev/boa/wiki/GSoC-2026",
-    "channels": [],
+    "channels": [
+      {
+        "type": "Matrix",
+        "url": "https://matrix.to/#/#boa:matrix.org",
+        "label": "Boa Matrix"
+      }
+    ],
     "mentors": [],
     "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "tip": "Join the Matrix room and introduce yourself before asking project-specific questions.",
+    "status": "ok",
+    "lastFetched": "2026-06-12T00:00:00.000Z"
   },
   "BRL-CAD": {
     "org": "BRL-CAD",


### PR DESCRIPTION
program: gssoc

## Related Issue
Closes #1673

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## What does this PR do?
Fixes missing mentor contact information for Blender Foundation and Boa
on the Mentors page. Both orgs had `"status": "no-contact-found"` with
empty `channels` in `data/mentors.json`.

## Root Cause
`data/mentors.json` had empty `channels` and `"status": "no-contact-found"`
for both Blender Foundation and Boa.

## Changes Made
- Updated `data/mentors.json` for **Blender Foundation**:
  - Added Forum channel → `https://devtalk.blender.org`
  - Added Chat channel → `https://chat.blender.org`
  - Updated status to `ok`
- Updated `data/mentors.json` for **Boa**:
  - Added Matrix channel → `https://matrix.to/#/#boa:matrix.org`
  - Updated status to `ok`

## Sources
- Blender Foundation: https://developer.blender.org/docs/programs/gsoc/ideas/
- Boa: https://www.gsocorganizations.dev/organization/boa/

## PR Checklist
- [x] Issue is assigned to me
- [x] PR links issue using `Closes #1673`
- [x] Changes are tested locally
- [x] No unnecessary dependencies added
- [x] Changes are focused (data-only fix for 2 orgs)
- [x] Commit messages follow conventional commits (`fix:`)
- [x] DCO sign-off included (`git commit -s`)

Closes #1673