### PR TITLE
Fix: remove rawScore from returned result object to prevent internal scoring leak

### DIFF
--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -35,7 +35,7 @@ function getRecommendations(resumeSkills = [], githubProfile = null) {
   );
   
   scoredOrgs.sort((a, b) => b.rawScore - a.rawScore);
-  return scoredOrgs.slice(0, 6);
+  return scoredOrgs.slice(0, 6).map(({ rawScore, ...rest }) => rest);
 }
 
 function calculateLanguageScore(userLanguages, orgTags, orgCat, matchedSkills, matchReasons) {

--- a/tests/recommendation.test.js
+++ b/tests/recommendation.test.js
@@ -18,10 +18,10 @@ test('getRecommendations returns top 6 recommendations sorted by score', () => {
   const recommendations = getRecommendations(resumeSkills, null);
 
   assert.strictEqual(recommendations.length, 6);
-  
-  // Verify they are sorted in descending order of rawScore
+  // Verify they are sorted in descending order of score
   for (let i = 0; i < recommendations.length - 1; i++) {
-    assert.ok(recommendations[i].rawScore >= recommendations[i + 1].rawScore);
+    assert.ok(recommendations[i].score >= recommendations[i + 1].score);
+  
   }
 
   // Each recommendation object must have required properties
@@ -29,7 +29,6 @@ test('getRecommendations returns top 6 recommendations sorted by score', () => {
     assert.ok('orgIndex' in rec);
     assert.ok('org' in rec);
     assert.ok('score' in rec);
-    assert.ok('rawScore' in rec);
     assert.ok(Array.isArray(rec.matchedSkills));
     assert.ok(Array.isArray(rec.reasons));
   });


### PR DESCRIPTION
program: gssoc

Closes #1865

## Summary
`getRecommendations()` was returning `rawScore` in every result object. This value is an internal tiebreaker used only for sorting — it was never meant to be exposed to the UI layer. Any code consuming the recommendations could access and potentially misuse this internal scoring detail.

## Root Cause
`calculateScoreForOrg()` attaches `rawScore` to the returned object for sorting purposes. After sorting, `rawScore` serves no further purpose but was still included in the final returned array.

## Fix
Sort using `rawScore` internally, then strip it from the results before returning using destructuring:

**Before:**
```js
scoredOrgs.sort((a, b) => b.rawScore - a.rawScore);
return scoredOrgs.slice(0, 6);
```

**After:**
```js
scoredOrgs.sort((a, b) => b.rawScore - a.rawScore);
return scoredOrgs.slice(0, 6).map(({ rawScore, ...rest }) => rest);
```

## Test Updates
Updated `tests/recommendation.test.js` to reflect that `rawScore` is no longer part of the public API:
- Removed `assert.ok('rawScore' in rec)` check
- Updated sort order assertion to use `score` instead of `rawScore`

## Files Changed
- `src/js/recommender.js` — 1 line changed
- `tests/recommendation.test.js` — 2 lines updated

## Testing
- ✅ All 25 tests pass (`npm test`)
- ✅ DCO sign-off included (`git commit -s`)
- ✅ No dependencies added
- ✅ No breaking changes to public API

## Screenshots

<img width="1918" height="497" alt="Screenshot 2026-06-13 234409" src="https://github.com/user-attachments/assets/79606f31-201f-4569-b9f5-13fa9b2d9f30" />

<img width="1918" height="540" alt="Screenshot 2026-06-13 234441" src="https://github.com/user-attachments/assets/402664f2-1477-4d28-936f-455eca16ce42" />


<img width="1918" height="1078" alt="Screenshot 2026-06-13 234457" src="https://github.com/user-attachments/assets/86328291-dbe2-495e-b903-413e779f0d97" />

## Related Issue
Closes #1865

## Type of Change
- [x] Bug fix (non-breaking)

## Checklist
- [x] Issue assigned to me
- [x] PR links issue using Closes #1865
- [x] Changes focused and minimal
- [x] No unnecessary dependencies
- [x] All 25 tests pass locally
- [x] DCO sign-off included
- [x] I understand every line submitted

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

