### PR TITLE
feat: add theme toggle to privacy page and sync theme state across tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2161,14 +2161,23 @@ kbd:hover{
   // THEME
   // ══════════════════════════════════════════════
   (function(){
-    const saved = localStorage.getItem('theme') || 'light';
+    let saved = 'light';
+    try {
+      saved = localStorage.getItem('theme') || 'light';
+    } catch(e) {
+      console.warn('LocalStorage read blocked/failed:', e);
+    }
     document.documentElement.classList.toggle('dark', saved === 'dark');
     updateThemeIcon();
   })();
 
   window.toggleTheme = function(){
     const isDark = document.documentElement.classList.toggle('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    try {
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    } catch(e) {
+      console.warn('LocalStorage write blocked/failed:', e);
+    }
     updateThemeIcon();
   };
 
@@ -2183,6 +2192,14 @@ kbd:hover{
       btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
     }
   }
+
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'theme') {
+      const isDark = e.newValue === 'dark';
+      document.documentElement.classList.toggle('dark', isDark);
+      updateThemeIcon();
+    }
+  });
 
   // ══════════════════════════════════════════════
   // MOBILE MENU

--- a/index.html
+++ b/index.html
@@ -2124,6 +2124,7 @@ kbd:hover{
 </div>
 
 <!-- ═══════════════════ JS ═══════════════════ -->
+<script src="src/js/theme.js"></script>
 <script src="agent/scripts/orgs.js"></script>
 <script>
   // ══════════════════════════════════════════════
@@ -2157,49 +2158,6 @@ kbd:hover{
     initializeOrgCounts();
   }
 
-  // ══════════════════════════════════════════════
-  // THEME
-  // ══════════════════════════════════════════════
-  (function(){
-    let saved = 'light';
-    try {
-      saved = localStorage.getItem('theme') || 'light';
-    } catch(e) {
-      console.warn('LocalStorage read blocked/failed:', e);
-    }
-    document.documentElement.classList.toggle('dark', saved === 'dark');
-    updateThemeIcon();
-  })();
-
-  window.toggleTheme = function(){
-    const isDark = document.documentElement.classList.toggle('dark');
-    try {
-      localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    } catch(e) {
-      console.warn('LocalStorage write blocked/failed:', e);
-    }
-    updateThemeIcon();
-  };
-
-  function updateThemeIcon(){
-    const btn = document.getElementById('themeToggleBtn');
-    const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
-    if(icon){
-      const isDark = document.documentElement.classList.contains('dark');
-      icon.textContent = isDark ? 'light_mode' : 'dark_mode';
-      btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
-      btn.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-      btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-    }
-  }
-
-  window.addEventListener('storage', (e) => {
-    if (e.key === 'theme') {
-      const isDark = e.newValue === 'dark';
-      document.documentElement.classList.toggle('dark', isDark);
-      updateThemeIcon();
-    }
-  });
 
   // ══════════════════════════════════════════════
   // MOBILE MENU

--- a/privacy.html
+++ b/privacy.html
@@ -40,6 +40,17 @@
       }
     }
   </script>
+  <style>
+    /* Dark mode overrides */
+    .dark body { background: #0f0f10 !important; color: #e5e7eb !important; }
+    .dark header { background: rgba(24, 24, 27, 0.85) !important; border-bottom: 1px solid #3f3f46 !important; }
+    .dark header .text-zinc-900 { color: #f4f4f5 !important; }
+    .dark header .text-zinc-600 { color: #a1a1aa !important; }
+    .dark header .hover\:text-zinc-900:hover { color: #f4f4f5 !important; }
+    .dark .text-zinc-900 { color: #f4f4f5 !important; }
+    .dark .text-zinc-600 { color: #a1a1aa !important; }
+    .dark .border-zinc-200 { border-color: #3f3f46 !important; }
+  </style>
 </head>
 <body class="privacy-page bg-surface text-zinc-900 antialiased selection:bg-orange-200 selection:text-orange-900 transition-colors duration-300">
 
@@ -57,6 +68,13 @@
       <a href="index.html#issues" class="text-sm font-bold text-zinc-600 hover:text-zinc-900 transition-colors">Issues</a>
     </nav>
     <div class="flex items-center gap-4">
+      <button id="themeToggleBtn" onclick="toggleTheme()"
+        class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-full transition-colors"
+        aria-label="Switch to dark theme" aria-pressed="false" title="Switch to dark theme">
+        <span class="material-symbols-outlined text-zinc-600">
+          dark_mode
+        </span>
+      </button>
       <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer" class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
         <span class="material-symbols-outlined text-sm">star</span> Star & Contribute
       </a>
@@ -89,6 +107,43 @@
 <!-- Footer Placeholder -->
 <div id="footer-placeholder"></div>
 <script src="src/js/footer.js"></script>
+
+<script>
+  // Theme initialization & switching logic
+  (function(){
+    updateThemeIcon();
+  })();
+
+  window.toggleTheme = function(){
+    const isDark = document.documentElement.classList.toggle('dark');
+    try {
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    } catch(e) {
+      console.warn('LocalStorage write blocked/failed:', e);
+    }
+    updateThemeIcon();
+  };
+
+  function updateThemeIcon(){
+    const btn = document.getElementById('themeToggleBtn');
+    const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
+    if(icon){
+      const isDark = document.documentElement.classList.contains('dark');
+      icon.textContent = isDark ? 'light_mode' : 'dark_mode';
+      btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+      btn.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+      btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+    }
+  }
+
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'theme') {
+      const isDark = e.newValue === 'dark';
+      document.documentElement.classList.toggle('dark', isDark);
+      updateThemeIcon();
+    }
+  });
+</script>
 
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -108,42 +108,7 @@
 <div id="footer-placeholder"></div>
 <script src="src/js/footer.js"></script>
 
-<script>
-  // Theme initialization & switching logic
-  (function(){
-    updateThemeIcon();
-  })();
-
-  window.toggleTheme = function(){
-    const isDark = document.documentElement.classList.toggle('dark');
-    try {
-      localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    } catch(e) {
-      console.warn('LocalStorage write blocked/failed:', e);
-    }
-    updateThemeIcon();
-  };
-
-  function updateThemeIcon(){
-    const btn = document.getElementById('themeToggleBtn');
-    const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
-    if(icon){
-      const isDark = document.documentElement.classList.contains('dark');
-      icon.textContent = isDark ? 'light_mode' : 'dark_mode';
-      btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
-      btn.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-      btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
-    }
-  }
-
-  window.addEventListener('storage', (e) => {
-    if (e.key === 'theme') {
-      const isDark = e.newValue === 'dark';
-      document.documentElement.classList.toggle('dark', isDark);
-      updateThemeIcon();
-    }
-  });
-</script>
+<script src="src/js/theme.js"></script>
 
 </body>
 </html>

--- a/src/js/theme.js
+++ b/src/js/theme.js
@@ -1,0 +1,55 @@
+// Theme initialization, toggling, and cross-tab synchronization logic
+
+(function(){
+  // Globally expose theme toggle function
+  window.toggleTheme = function(){
+    const isDark = document.documentElement.classList.toggle('dark');
+    try {
+      localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    } catch(e) {
+      console.warn('LocalStorage write blocked/failed:', e);
+    }
+    updateThemeIcon();
+  };
+
+  // Helper to update the UI theme toggle button state and icon
+  function updateThemeIcon(){
+    const btn = document.getElementById('themeToggleBtn');
+    const icon = btn ? btn.querySelector('.material-symbols-outlined') : null;
+    if(icon){
+      const isDark = document.documentElement.classList.contains('dark');
+      icon.textContent = isDark ? 'light_mode' : 'dark_mode';
+      btn.setAttribute('aria-pressed', isDark ? 'true' : 'false');
+      btn.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+      btn.setAttribute('title', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+    }
+  }
+
+  // Synchronize theme changes across open tabs/windows
+  window.addEventListener('storage', (e) => {
+    if (e.key === 'theme') {
+      const isDark = e.newValue === 'dark';
+      document.documentElement.classList.toggle('dark', isDark);
+      updateThemeIcon();
+    }
+  });
+
+  // Function to initialize theme state on load
+  function initTheme(){
+    let saved = 'light';
+    try {
+      saved = localStorage.getItem('theme') || 'light';
+    } catch(e) {
+      console.warn('LocalStorage read blocked/failed:', e);
+    }
+    document.documentElement.classList.toggle('dark', saved === 'dark');
+    updateThemeIcon();
+  }
+
+  // Run initial theme check and icon update once the DOM is ready (or immediately if already parsed)
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTheme);
+  } else {
+    initTheme();
+  }
+})();


### PR DESCRIPTION
## Related Issue
Closes #1903 

program: gssoc

## Description
This PR implements a light/dark theme toggle button and full dark mode support on the Privacy Policy page (privacy.html), matching the visual layout, typography, and design aesthetics of the main landing page (index.html). It also introduces real-time tab synchronization using the browser storage event, ensuring all open tabs of the site switch themes in lockstep when the toggler is clicked.

## Changes Made

- Added a theme toggle button (#themeToggleBtn) inside the header right-side menu container on privacy.html.
- Implemented inline CSS dark mode overrides (.dark namespace) in privacy.html for body background, header backgrounds, typography, and border colors.
- Added inline JavaScript theme switching and icon updater logic to the bottom of the body in privacy.html.
- Added window storage event listeners to both index.html and privacy.html to sync theme state changes across multiple open tabs in real-time.
- Wrapped localStorage read/write operations in standard try-catch blocks to prevent script crashes in browsers blocking storage access (such as private tabs, sandboxed runtimes, or when opening pages via file://).

## Type of Change
New Feature / Refactor

## Checklist

- [ ]  Tested locally
- [ ]  Linked related issue
- [ ]  DCO sign-off included
- [ ]  Changes are limited to this issue

## Program
GSSoC 2026



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

