### PR TITLE
fix: update X (Twitter) social icon to use official branding colors

### DIFF
--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -132,7 +132,7 @@
             d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.779-1.75-1.75s.784-1.75 1.75-1.75 1.75.779 1.75 1.75-.784 1.75-1.75 1.75zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
         </svg>
       </a>
-      <a class="social-link twitter" href="https://x.com/S3DXVI" target="_blank" rel="noopener noreferrer"
+      <a class="social-link x" href="https://x.com/S3DXVI" target="_blank" rel="noopener noreferrer"
         aria-label="Twitter/X Profile">
         <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24">
           <path

--- a/src/styles.css
+++ b/src/styles.css
@@ -520,11 +520,13 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
   box-shadow: 0 0 12px rgba(10, 102, 194, 0.5);
 }
 
-.social-link.twitter:hover {
-  background: #1DA1F2;
-  border-color: #1DA1F2;
-  box-shadow: 0 0 12px rgba(29, 161, 242, 0.5);
+.social-link.twitter:hover,
+.social-link.x:hover {
+  background: #000000;
+  border-color: #000000;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.5);
 }
+
 
 #back-to-top-btn {
   position: fixed;


### PR DESCRIPTION

## Description
This PR resolves the visual inconsistency of the X (formerly Twitter) social icon in the website footer. Previously, the X icon hovered with the old Twitter light blue background (`#1DA1F2`). To align with the updated branding design of other social icons (such as GitHub, Discord, and LinkedIn), the hover background has been updated to the official X brand color (black).

##Closes #1895 

## Changes
- **HTML Component** (`src/components/footer.html`):
  - Updated the anchor tag class for the X icon from `twitter` to `x`.
- **CSS Styles** (`src/styles.css`):
  - Added support for `.x` class under hover social-link styles.
  - Changed background color, border color, and shadow on hover to `#000000` (black) and `rgba(0, 0, 0, 0.5)` respectively.

## Verification
- Ran local static server and visually verified the hover behavior across dark and light themes.
- Checked that linter and all 25 tests pass (`npm run lint && npm run test`).

## Visual Changes
| State | Hover Style (Before) | Hover Style (After) |
|---|---|---|
| **X (Twitter)** | Light Blue (`#1DA1F2`) | Black (`#000000`) |


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

