### PR TITLE
Fix: Added toast functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -3539,6 +3539,7 @@ btn.__orgListenerAttached = true;
     let t = document.getElementById('compareToast');
     if (!t) {
       t = document.createElement('div');
+      t.id = 'compareToast';
       t.setAttribute('role', 'status');
       t.setAttribute('aria-live', 'polite');
       t.setAttribute('aria-atomic', 'true');

--- a/index.html
+++ b/index.html
@@ -3541,19 +3541,20 @@ btn.__orgListenerAttached = true;
     if(!t) {
       t=document.createElement('div');
       t.id='compareToast';
-      t.style.cssText='
-        position:fixed;bottom:24px;
-        left:50%;
-        transform:translateX(-50%);
-        background:var(--ink);
-        color:var(--bg);
-        padding:10px 18px;
-        border-radius:8px;
-        font-size:12px;
-        font-weight:700;
-        z-index:999;
-        transition:opacity .3s;white-space:nowrap';
-        document.body.appendChild(t);
+      t.style.cssText='position:fixed;
+      bottom:24px;
+      left:50%;
+      transform:translateX(-50%);
+      background:var(--ink);
+      color:var(--bg);
+      padding:10px 18px;
+      border-radius:8px;
+      font-size:12px;
+      font-weight:700;
+      z-index:999;
+      transition:opacity .3s;
+      white-space:nowrap';
+      document.body.appendChild(t);
     }
     t.textContent=msg;
     t.style.opacity='1';

--- a/index.html
+++ b/index.html
@@ -3535,36 +3535,23 @@ btn.__orgListenerAttached = true;
     });
   }
 
-  
   function showToast(msg) {
-    let t=document.getElementById('compareToast');
-    if(!t) {
-      t=document.createElement('div');
-      t.id='compareToast';
+    let t = document.getElementById('compareToast');
+    if (!t) {
+      t = document.createElement('div');
+      t.className = 'compareToast';
       t.setAttribute('role', 'status');
       t.setAttribute('aria-live', 'polite');
       t.setAttribute('aria-atomic', 'true');
-      t.style.cssText='position:fixed;
-      bottom:24px;
-      left:50%;
-      transform:translateX(-50%);
-      background:var(--ink);
-      color:var(--bg);
-      padding:10px 18px;
-      border-radius:8px;
-      font-size:12px;
-      font-weight:700;
-      z-index:999;
-      transition:opacity .3s;
-      white-space:nowrap';
+      t.className = 'compare-toast';
+      t.style.opacity = '0';
       document.body.appendChild(t);
     }
-    t.textContent=msg;
-    t.style.opacity='1';
+    t.textContent = msg;
     clearTimeout(t._hideTimeout);
-    t._hideTimeout = setTimeout(()=>t.style.opacity='0',2200);
+    requestAnimationFrame(() => requestAnimationFrame(() => { t.style.opacity = '1'; }));
+    t._hideTimeout = setTimeout(() => { t.style.opacity = '0'; }, 2200);
   }
-
 
   function toggleCompare(e, name) {
     if (e) e.stopPropagation();
@@ -5177,7 +5164,7 @@ if(org.ideas){
   
   class SafeHTMLString extends String {}
   SafeHTMLString.prototype.__isSafeHTML = true;
-
+ 
   function safeHTML(strings, ...values) {
     let result = '';
     for (let i = 0; i < strings.length; i++) {

--- a/index.html
+++ b/index.html
@@ -3541,6 +3541,9 @@ btn.__orgListenerAttached = true;
     if(!t) {
       t=document.createElement('div');
       t.id='compareToast';
+      t.setAttribute('role', 'status');
+      t.setAttribute('aria-live', 'polite');
+      t.setAttribute('aria-atomic', 'true');
       t.style.cssText='position:fixed;
       bottom:24px;
       left:50%;
@@ -3577,8 +3580,7 @@ btn.__orgListenerAttached = true;
     }
     renderOrgs(true);
     renderCompare();
-
-    //document.dispatchEvent(new CustomEvent('compareListChanged'));
+    document.dispatchEvent(new CustomEvent('compareListChanged'));
   }
 
   function renderCompare() {

--- a/index.html
+++ b/index.html
@@ -3535,6 +3535,33 @@ btn.__orgListenerAttached = true;
     });
   }
 
+  
+  function showToast(msg) {
+    let t=document.getElementById('compareToast');
+    if(!t) {
+      t=document.createElement('div');
+      t.id='compareToast';
+      t.style.cssText='
+        position:fixed;bottom:24px;
+        left:50%;
+        transform:translateX(-50%);
+        background:var(--ink);
+        color:var(--bg);
+        padding:10px 18px;
+        border-radius:8px;
+        font-size:12px;
+        font-weight:700;
+        z-index:999;
+        transition:opacity .3s;white-space:nowrap';
+        document.body.appendChild(t);
+    }
+    t.textContent=msg;
+    t.style.opacity='1';
+    clearTimeout(t._hideTimeout);
+    t._hideTimeout = setTimeout(()=>t.style.opacity='0',2200);
+  }
+
+
   function toggleCompare(e, name) {
     if (e) e.stopPropagation();
     const idx = compareList.indexOf(name);
@@ -3542,7 +3569,7 @@ btn.__orgListenerAttached = true;
       compareList.splice(idx, 1);
     } else {
       if (compareList.length >= 3) {
-        alert("You can only compare up to 3 organizations at a time.");
+        showToast("You can only compare up to 3 organizations at a time.");
         return;
       }
       compareList.push(name);
@@ -3550,7 +3577,7 @@ btn.__orgListenerAttached = true;
     renderOrgs(true);
     renderCompare();
 
-    document.dispatchEvent(new CustomEvent('compareListChanged'));
+    //document.dispatchEvent(new CustomEvent('compareListChanged'));
   }
 
   function renderCompare() {

--- a/index.html
+++ b/index.html
@@ -3539,7 +3539,6 @@ btn.__orgListenerAttached = true;
     let t = document.getElementById('compareToast');
     if (!t) {
       t = document.createElement('div');
-      t.className = 'compareToast';
       t.setAttribute('role', 'status');
       t.setAttribute('aria-live', 'polite');
       t.setAttribute('aria-atomic', 'true');

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -103,12 +103,11 @@ function handleCompareAction(e, btn, card) {
 }
 
 function handleCardActivation(card) {
-  const idx = parseInt(card.dataset.orgIndex, 10);
-  if (typeof openModal === 'function' && !isNaN(idx) && idx >= 0) {
-    openModal(idx);
+  const name = card.dataset.orgName;
+  if (typeof openModal === 'function' && name) {
+    openModal(name);
   }
 }
-
 
 document.addEventListener('DOMContentLoaded', () => {
   const getRecsBtn = document.getElementById('btnGetRecommendations');

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -103,9 +103,9 @@ function handleCompareAction(e, btn, card) {
 }
 
 function handleCardActivation(card) {
-  const name = card.dataset.orgName;
-  if (typeof openModal === 'function' && name) {
-    openModal(name);
+  const idx = parseInt(card.dataset.orgIndex, 10);
+  if (typeof openModal === 'function' && !isNaN(idx) && idx >= 0) {
+    openModal(idx);
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -844,3 +844,25 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 }
 
 
+/* ai-recommendation page */
+.compare-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 90vw;
+  text-align: center;
+  padding: 0.6rem 1.1rem;
+  border-radius: 9999px;
+  background: var(--color-zinc-900, #18181b);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Changes
- Removed native alert() from toggleCompare() in index.html
- Added showCompareToast() helper in the same script scope
- Toast auto dismisses after 2.2s, non-blocking & matches existing UI
- Implemented clearTimeout functionality

## Testing & Screenshot
- Tested locally: added 3 orgs to compare, 4th click shows toast
<img width="1911" height="1034" alt="image" src="https://github.com/user-attachments/assets/15e9c416-bf9f-45b3-b151-34e0a9cbfa37" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/fe893d9e-5e21-481c-95ba-6edf236543b6" />

## Closes #1737
## Related issue: #1737
## Type of change: bug
program: gssoc


## Acceptance Criteria
- [x]  Native alert() in toggleCompare() is removed
- [x]  A styled toast appears when user tries to add a 4th org
- [x]  Toast auto-dismisses after a few seconds
- [x]  No page blocking behavior

## 🌱 Contributor Checklist

- [x]  I am participating via GSSoC
- [x]  I have read the contribution guidelines
- [x]  I checked for existing issues before creating this

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

