### PR TITLE
fix: add history.replaceState to clearAllFilters to clean URL on rese…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4257,7 +4257,7 @@ if(org.ideas){
 
     filteredOrgs = [...ORGS];
     renderOrgs(true);
-    applyFilters(); // to reset URL params
+    history.replaceState(null, '', location.pathname); applyFilters(); // reset URL params and re-render with clean state
   };
 
   // Shared search function to handle filter application, with optional badge tracking


### PR DESCRIPTION
Fixes #1053

## Summary

`clearAllFilters()` in `index.html` was missing `history.replaceState()` to clean the URL after resetting filters. This caused stale URL params to persist, so sharing or refreshing after clearing would restore all supposedly cleared filters.

## Changes
- Added `history.replaceState(null, '', location.pathname)` before `applyFilters()` in `clearAllFilters()` to clean the URL query string on reset

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

