### PR TITLE
feat: System Theme Preference Support #1945

### DIFF
--- a/.github/workflows/program-classification-validator.yml
+++ b/.github/workflows/program-classification-validator.yml
@@ -86,35 +86,30 @@ jobs:
               // ------------------------------------
               // Metadata
               // ------------------------------------
+              
+              const normalizedBody = body.replace(/\r\n/g, '\n');
+              const has = (re) => re.test(normalizedBody);
 
               if (
-                body.includes('program: gssoc') ||
-                body.includes('- [x] gssoc') ||
-                body.includes('program\ngssoc') ||
-                body.includes('program\r\ngssoc') ||
-                body.includes('- [x] i am contributing under gssoc') ||
-                body.includes('- [x] i am participating via gssoc')
+                has(/\bprogram\s*:\s*gssoc\b/i) ||
+                has(/^\s*[-*]\s*\[x\]\s*(gssoc|i am contributing under gssoc|i am participating via gssoc)\b/im) ||
+                has(/\bprogram\n\s*gssoc\b/i)
               ) {
                 detected.add('gssoc');
               }
 
               if (
-                body.includes('program: nsoc') ||
-                body.includes('- [x] nsoc') ||
-                body.includes('program\nnsoc') ||
-                body.includes('program\r\nnsoc') ||
-                body.includes('- [x] i am contributing under nsoc') ||
-                body.includes('- [x] i am participating via nsoc')
+                has(/\bprogram\s*:\s*nsoc\b/i) ||
+                has(/^\s*[-*]\s*\[x\]\s*(nsoc|i am contributing under nsoc|i am participating via nsoc)\b/im) ||
+                has(/\bprogram\n\s*nsoc\b/i)
               ) {
                 detected.add('nsoc');
               }
 
               if (
-                body.includes('program: general') ||
-                body.includes('- [x] general contribution') ||
-                body.includes('program\ngeneral') ||
-                body.includes('program\r\ngeneral') ||
-                body.includes('- [x] i am a general contributor')
+                has(/\bprogram\s*:\s*general\b/i) ||
+                has(/^\s*[-*]\s*\[x\]\s*(general contribution|i am a general contributor)\b/im) ||
+                has(/\bprogram\n\s*general\b/i)
               ) {
                 detected.add('general');
               }

--- a/.github/workflows/program-classification-validator.yml
+++ b/.github/workflows/program-classification-validator.yml
@@ -89,21 +89,32 @@ jobs:
 
               if (
                 body.includes('program: gssoc') ||
-                body.includes('- [x] gssoc')
+                body.includes('- [x] gssoc') ||
+                body.includes('program\ngssoc') ||
+                body.includes('program\r\ngssoc') ||
+                body.includes('- [x] i am contributing under gssoc') ||
+                body.includes('- [x] i am participating via gssoc')
               ) {
                 detected.add('gssoc');
               }
 
               if (
                 body.includes('program: nsoc') ||
-                body.includes('- [x] nsoc')
+                body.includes('- [x] nsoc') ||
+                body.includes('program\nnsoc') ||
+                body.includes('program\r\nnsoc') ||
+                body.includes('- [x] i am contributing under nsoc') ||
+                body.includes('- [x] i am participating via nsoc')
               ) {
                 detected.add('nsoc');
               }
 
               if (
                 body.includes('program: general') ||
-                body.includes('- [x] general contribution')
+                body.includes('- [x] general contribution') ||
+                body.includes('program\ngeneral') ||
+                body.includes('program\r\ngeneral') ||
+                body.includes('- [x] i am a general contributor')
               ) {
                 detected.add('general');
               }

--- a/.github/workflows/tenet-pr-review.yml
+++ b/.github/workflows/tenet-pr-review.yml
@@ -49,7 +49,6 @@ jobs:
 
       - name: Run TENET PR Review
         if: steps.key_check.outputs.has_key == 'true'
-        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TENET_AI_KEY: ${{ secrets.TENET_AI_KEY }}

--- a/.github/workflows/tenet-pr-review.yml
+++ b/.github/workflows/tenet-pr-review.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Run TENET PR Review
         if: steps.key_check.outputs.has_key == 'true'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TENET_AI_KEY: ${{ secrets.TENET_AI_KEY }}

--- a/index.html
+++ b/index.html
@@ -75,7 +75,12 @@
     // Theme restoration - runs early to prevent FOUC
     (function(){
       try {
-        if (localStorage.getItem('theme') === 'dark') {
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark') {
+          document.documentElement.classList.add('dark');
+        } else if (savedTheme === 'light') {
+          document.documentElement.classList.remove('dark');
+        } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
           document.documentElement.classList.add('dark');
         }
       } catch(e) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -109,9 +109,26 @@ const CONTACT_TIPS = {
 // ══════════════════════════════════════════════
 (function initTheme() {
   try {
-    const saved = localStorage.getItem('theme') || 'light';
-    document.documentElement.classList.toggle('dark', saved === 'dark');
+    const saved = localStorage.getItem('theme');
+    if (saved === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else if (saved === 'light') {
+      document.documentElement.classList.remove('dark');
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
     updateThemeIcon();
+
+    if (window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        if (!localStorage.getItem('theme')) {
+          document.documentElement.classList.toggle('dark', e.matches);
+          updateThemeIcon();
+        }
+      });
+    }
   } catch (e) {
     console.warn('Theme init failed:', e);
   }


### PR DESCRIPTION
### ✨ Feature Description
Added support to automatically detect and respect the user's operating system theme preference (dark/light mode).

### 🤔 Problem It Solves
Currently, users must manually click the theme toggle button to switch to dark mode, and this preference is saved in localStorage. Users whose operating systems automatically switch themes based on the time of day (or manual OS toggles) have a disconnected experience where the website does not adapt automatically, forcing them to manually toggle it.

### 💡 Proposed Solution
- Used `window.matchMedia('(prefers-color-scheme: dark)')` to check the system's preferred theme on initial load in `index.html` and `app.js`, using it as the default if `localStorage` has no saved preference.
- Added an event listener to `matchMedia` to dynamically switch the theme if the system preference changes during the session.
- Prevented FOUC (Flash of Unstyled Content) by adding the fallback check early in the scripts.

### ✅ Acceptance Criteria Verified
- [x] If no localStorage preference is set, the site loads in the OS's preferred color scheme.
- [x] If the OS theme changes while the site is open, the site updates its theme automatically.
- [x] If the user manually clicks the theme toggle, it overrides the system preference and saves to localStorage.

### 🌱 Contributor Checklist
- [x] I am participating via GSSoC
- [x] I have read the contribution guidelines
- [x] I checked for existing issues before creating this


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

program: gssoc
