### PR TITLE
fix: update mentor contact information for Stichting SU2 

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -4242,15 +4242,73 @@
   "lastFetched": "2026-05-09T16:09:12.548Z"
 },
   "Stichting SU2": {
-    "org": "Stichting SU2",
-    "ideasUrl": "https://su2code.github.io/gsoc.html",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "fetch-failed",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
-  },
+  "org": "Stichting SU2",
+  "ideasUrl": "https://su2code.github.io/gsoc/Introduction/",
+  "channels": [
+    {
+      "type": "Slack",
+      "url": "https://su2foundation.slack.com",
+      "label": "SU2 Slack"
+    }
+  ],
+  "mentors": [
+    {
+      "name": "Nitish Anand",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Edwin van der Weide",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Pedro Gomes",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Ole Burghardt",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Nijso Beishuizen",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Joshua A. Kelly",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Harsh Mishra",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Evert Bunschoten",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Huseyin Ozdemir",
+      "github": "",
+      "githubUrl": ""
+    }
+  ],
+  "mailingLists": [
+    {
+      "type": "Email",
+      "url": "mailto:gsoc@su2foundation.org",
+      "label": "SU2 GSoC Email"
+    }
+  ],
+  "tip": "Join the SU2 Slack community, complete the participation assignments, and interact with mentors before submitting a GSoC proposal.",
+  "status": "ok",
+  "lastFetched": "2026-06-24T22:40:00.000Z"
+},
 "Submitty": {
   "org": "Submitty",
   "ideasUrl": "https://github.com/Submitty/Submitty/wiki/Google-Summer-of-Code",


### PR DESCRIPTION
program: GSSOC

# Description

Updated mentor contact information for Stichting SU2 by verifying the official GSoC 2026 ideas page and community resources. Added verified Slack communication channel, mentor information from the GSoC 2026 ideas page, mailing list details, contributor guidance, updated the ideas page URL, and changed the organization status from fetch-failed to ok.

# Related Issue

Closes #405

# Type of Change

[x] Documentation update
[x] Data update

# Checklist

[x] Issue assigned to me
[x] Changes are focused and relevant
[x] Verified information from official sources
[x] Linked the related issue
[x] Followed repository guidelines

# Source

* SU2 GSoC 2026 Ideas Page
* SU2 Student Participation Page
* SU2 GitHub Repository
* SU2 Slack Community


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

