### PR TITLE
fix: update mentors.json for MIT App Inventor

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2379,12 +2379,31 @@
     "ideasUrl": "https://github.com/mit-cml/appinventor-sources/wiki/Google-Summer-of-Code-2026",
     "channels": [],
     "mentors": [
-      "Natalie Lao",
-      "Susan Rati Lane",
-      "Evan Patton",
-      "Jose Dominguez",
-      "Jeff Schiller",
-      "Mark Friedman"
+      {
+      "name": "Natalie Lao",
+        "github": "",
+        "githubUrl": ""
+      },
+      "name": "Susan Rati Lane",
+        "github": "",
+        "githubUrl": ""
+      },
+      "name": "Evan Patton",
+         "github": "",
+        "githubUrl": ""
+      },
+      "name": "Jose Dominguez",
+         "github": "",
+        "githubUrl": ""
+      },
+      "name": "Jeff Schiller",
+         "github": "",
+        "githubUrl": ""
+      },
+      "name": "Mark Friedman"
+        "github": "",
+        "githubUrl": ""
+      }
     ],
     "mailingLists": [],
     "tip": "",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2380,32 +2380,32 @@
     "channels": [],
     "mentors": [
       {
-      "name": "Natalie Lao",
+        "name": "Natalie Lao",
         "github": "",
         "githubUrl": ""
       },
       {
-      "name": "Susan Rati Lane",
+        "name": "Susan Rati Lane",
         "github": "SusanRatiLane",
         "githubUrl": "https://github.com/SusanRatiLane"
       },
       {
-      "name": "Evan Patton",
-         "github": "ewpatton",
+        "name": "Evan Patton",
+        "github": "ewpatton",
         "githubUrl": "https://github.com/ewpatton"
       },
       {
-      "name": "Jose Dominguez",
-         "github": "",
+        "name": "Jose Dominguez",
+        "github": "",
         "githubUrl": ""
       },
       {
-      "name": "Jeff Schiller",
-         "github": "jisqyv",
+        "name": "Jeff Schiller",
+        "github": "jisqyv",
         "githubUrl": "https://github.com/jisqyv"
       },
       {
-      "name": "Mark Friedman"
+        "name": "Mark Friedman",
         "github": "",
         "githubUrl": ""
       }

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2378,10 +2378,17 @@
     "org": "MIT App Inventor",
     "ideasUrl": "https://github.com/mit-cml/appinventor-sources/wiki/Google-Summer-of-Code-2026",
     "channels": [],
-    "mentors": [],
+    "mentors": [
+      "Natalie Lao",
+      "Susan Rati Lane",
+      "Evan Patton",
+      "Jose Dominguez",
+      "Jeff Schiller",
+      "Mark Friedman"
+    ],
     "mailingLists": [],
     "tip": "",
-    "status": "no-contact-found",
+    "status": "ok",
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Mixxx": {

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -2384,22 +2384,27 @@
         "github": "",
         "githubUrl": ""
       },
+      {
       "name": "Susan Rati Lane",
-        "github": "",
-        "githubUrl": ""
+        "github": "SusanRatiLane",
+        "githubUrl": "https://github.com/SusanRatiLane"
       },
+      {
       "name": "Evan Patton",
-         "github": "",
-        "githubUrl": ""
+         "github": "ewpatton",
+        "githubUrl": "https://github.com/ewpatton"
       },
+      {
       "name": "Jose Dominguez",
          "github": "",
         "githubUrl": ""
       },
+      {
       "name": "Jeff Schiller",
-         "github": "",
-        "githubUrl": ""
+         "github": "jisqyv",
+        "githubUrl": "https://github.com/jisqyv"
       },
+      {
       "name": "Mark Friedman"
         "github": "",
         "githubUrl": ""


### PR DESCRIPTION
## Program

program: gssoc

## Related Issue

Closes #353

## Description

- Verified the MIT App Inventor GSoC 2026 ideas page URL.
- Researched and added available mentor information.
- Added available GitHub handles for mentors where publicly verifiable.
- Updated the organization status from "no-contact-found" to "ok" after verification.
- Fixed the missing JSON comma reported during the previous review.

## Type of Change

- Mentor data verification
- Contact information update
- Repository data maintenance

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

