### PR TITLE
fix: update routing links in landing.html for Vercel rewrite rules

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -10,7 +10,7 @@
   <title>FindMyGSoC — Discover GSoC 2026 Orgs & Live GitHub Issues</title>
   <meta name="description"
     content="Discover Google Summer of Code 2026 organizations, track live beginner-friendly Good First Issues, match your skills with AI, and compare orgs side-by-side." />
-  <link rel="canonical" href="https://findmygsoc.vercel.app/landing.html" />
+  <link rel="canonical" href="https://findmygsoc.vercel.app/" />
 
   <!-- SEO & Social Meta Tags -->
   <meta property="og:type" content="website" />
@@ -18,7 +18,7 @@
   <meta property="og:title" content="FindMyGSoC — Live GSoC 2026 Org Finder & GFI Tracker" />
   <meta property="og:description"
     content="Find your best-fit GSoC 2026 organization and track live beginner-friendly Good First Issues." />
-  <meta property="og:url" content="https://findmygsoc.vercel.app/landing.html" />
+  <meta property="og:url" content="https://findmygsoc.vercel.app/" />
   <meta property="og:image" content="https://findmygsoc.vercel.app/src/assets/og-image.jpeg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="FindMyGSoC — Live GSoC 2026 Org Finder" />
@@ -63,7 +63,7 @@
     class="fixed top-0 w-full z-50 bg-white/80 dark:bg-[#0f0a05]/80 glass border-b border-zinc-200/50 dark:border-zinc-800/50 shadow-sm transition-colors duration-300">
     <div class="flex items-center justify-between px-4 sm:px-6 py-3.5 max-w-7xl mx-auto w-full">
       <div class="flex items-center gap-8">
-        <a href="landing.html"
+        <a href="/"
           class="flex items-center gap-2.5 group transition-transform duration-300 hover:scale-[1.03]">
           <div
             class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0 shadow-md shadow-orange-500/20 group-hover:rotate-6 transition-transform duration-300">
@@ -97,7 +97,7 @@
         </button>
 
         <!-- Launch App CTA -->
-        <a href="index.html"
+        <a href="/app"
           class="hidden sm:inline-flex items-center gap-2 px-5 py-2.5 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 text-xs font-bold rounded-xl hover:bg-primary hover:text-white dark:hover:bg-primary dark:hover:text-white transition-all shadow-md hover:shadow-orange-500/20 active:scale-95 duration-200">
           Launch Application
           <span class="material-symbols-outlined text-sm">rocket_launch</span>
@@ -125,7 +125,7 @@
         <a class="text-zinc-600 hover:text-primary dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
           href="#faq">FAQ</a>
       </nav>
-      <a href="index.html"
+      <a href="/app"
         class="flex items-center justify-center gap-2 w-full px-5 py-3 bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 text-sm font-bold rounded-xl hover:bg-primary hover:text-white dark:hover:bg-primary dark:hover:text-white transition-all shadow-md">
         Launch Application
         <span class="material-symbols-outlined text-sm">rocket_launch</span>
@@ -198,7 +198,7 @@
 
       <!-- Action Buttons -->
       <div class="hero-entry hero-entry-4 flex flex-col sm:flex-row items-center justify-center gap-4 mb-6">
-        <a href="index.html" id="hero-launch-btn"
+        <a href="/app" id="hero-launch-btn"
           class="group w-full sm:w-auto inline-flex items-center justify-center gap-2.5 px-9 py-4 bg-gradient-to-r from-primary via-orange-500 to-amber-500 text-white rounded-2xl text-base font-bold shadow-xl shadow-orange-500/30 hover:shadow-2xl hover:shadow-orange-500/40 hover:scale-[1.04] transition-all duration-200 active:scale-95 relative overflow-hidden">
           <!-- Glow ring on hover -->
           <span
@@ -1056,7 +1056,7 @@
 
         <!-- Bottom CTA row -->
         <div class="mt-16 flex flex-col sm:flex-row items-center justify-center gap-4">
-          <a href="index.html"
+          <a href="/app"
             class="inline-flex items-center gap-2.5 px-7 py-3.5 bg-gradient-to-r from-primary to-orange-500 text-white rounded-2xl text-sm font-bold shadow-lg shadow-orange-500/25 hover:shadow-xl hover:shadow-orange-500/35 hover:scale-[1.04] transition-all duration-200 active:scale-95">
             <span class="material-symbols-outlined text-base">rocket_launch</span>
             Start Your Journey Now
@@ -1098,7 +1098,7 @@
           GSoC Slot?</h2>
         <p class="text-zinc-400 max-w-xl mx-auto text-sm sm:text-base mb-8 relative z-10">Launch the application,
           compare organizations, filter tech stacks, and find good first issues instantly.</p>
-        <a href="index.html"
+        <a href="/app"
           class="inline-flex items-center gap-2.5 px-8 py-4 bg-primary hover:bg-primary-container text-white text-base font-bold rounded-2xl transition-all duration-200 shadow-md relative z-10 hover:scale-[1.02]">
           Launch Finder Dashboard
           <span class="material-symbols-outlined text-lg">rocket_launch</span>

--- a/src/js/landing.js
+++ b/src/js/landing.js
@@ -266,7 +266,7 @@ function applyFooterPatch(footer) {
   footer.querySelectorAll('a').forEach((a) => {
     const href = a.getAttribute('href');
     if (href === '#orgs' || href === '#timeline') {
-      a.setAttribute('href', `index.html${href}`);
+      a.setAttribute('href', `/app${href}`);
     }
   });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,9 @@
   "outputDirectory": ".",
   "buildCommand": "",
   "devCommand": "npx serve . -l $PORT",
-  "redirects": [
-    { "source": "/", "destination": "/landing.html", "permanent": false }
-  ],
   "rewrites": [
+    { "source": "/", "destination": "/landing.html" },
+    { "source": "/app", "destination": "/index.html" },
     { "source": "/api/github", "destination": "/api/github.js" }
   ],
   "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
   "rewrites": [
     { "source": "/", "destination": "/landing.html" },
     { "source": "/app", "destination": "/index.html" },
+    { "source": "/app/:path*", "destination": "/index.html" },
     { "source": "/api/github", "destination": "/api/github.js" }
   ],
   "headers": [


### PR DESCRIPTION
##Program
GSSOC

## Description
The `vercel.json` rewrites map `/` to `landing.html` and `/app` to `index.html`.
All CTA buttons were still linking to `index.html` directly, which breaks navigation under the new routing setup.

## Changes
- `href="index.html"` → `href="/app"` (navbar, mobile menu, hero CTA, how-it-works CTA, banner CTA)
- `href="landing.html"` → `href="/"` (logo link)
- Updated canonical URL and `og:url` meta tags from `/landing.html` → `/`
- - `index.html#orgs` / `index.html#timeline` → `/app#orgs` / `/app#timeline` in `src/js/landing.js` (footer injected links)

## Result
All links in `landing.html` now correctly route through Vercel's rewrite rules, ensuring smooth navigation between the landing page and the main application.
Footer links dynamically injected by landing.js now also correctly route through Vercel's rewrite rules.

## Related Issue
Fixes #1974 

## 📸 Screenshot

### Before:
<img width="1655" height="841" alt="image" src="https://github.com/user-attachments/assets/5047eead-24eb-4a90-9456-44004569dea9" />

### After:
<img width="1896" height="910" alt="image" src="https://github.com/user-attachments/assets/ba0477d2-4528-472f-979f-a8be42066aae" />
<img width="1900" height="918" alt="image" src="https://github.com/user-attachments/assets/89928e6f-d46b-426f-bcaf-76afdc6d5a9f" />

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

