### PR TITLE
fix: navbar overflows and clips on iPad portrait mode , collapse it to hamburger menu at tablet portrait breakpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -1201,7 +1201,7 @@ kbd:hover{
 <!-- ═══════════════════ NAVBAR ═══════════════════ -->
 <header class="fixed top-0 w-full z-50 bg-white/80 glass shadow-sm">
   <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
-    <div class="flex items-center gap-3 sm:gap-4 lg:gap-8">
+    <div class="flex items-center gap-3 sm:gap-4 xl:gap-8">
       <!-- Hamburger menu button (mobile only) -->
       <button id="menuBtn" onclick="toggleMenu()" class="inline-flex lg:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-zinc-600">menu</span>
@@ -1216,7 +1216,7 @@ kbd:hover{
         <span class="text-primary italic">Org Finder</span>
       </span>
       </a>
-      <nav class="hidden lg:flex items-center gap-6 text-sm font-medium">
+      <nav class="hidden lg:flex items-center gap-4 xl:gap-6 text-sm font-medium">
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#orgs" data-section="orgs">Organizations</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
@@ -1261,13 +1261,14 @@ kbd:hover{
       </button>
     
       <a href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank" rel="noopener noreferrer"
-        class="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors">
-    
+        class="hidden sm:flex items-center gap-2 px-3 xl:px-4 py-2 rounded-full bg-zinc-900 text-white text-xs font-bold hover:bg-zinc-700 transition-colors whitespace-nowrap">
+
         <span class="material-symbols-outlined text-sm">
           star
         </span>
-    
-        Star & Contribute
+
+        <span class="lg:hidden xl:inline">Star & Contribute</span>
+        <span class="hidden lg:inline xl:hidden">Star</span>
       </a>
     
     </div>

--- a/index.html
+++ b/index.html
@@ -1201,9 +1201,9 @@ kbd:hover{
 <!-- ═══════════════════ NAVBAR ═══════════════════ -->
 <header class="fixed top-0 w-full z-50 bg-white/80 glass shadow-sm">
   <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
-    <div class="flex items-center gap-3 sm:gap-4 md:gap-8">
+    <div class="flex items-center gap-3 sm:gap-4 lg:gap-8">
       <!-- Hamburger menu button (mobile only) -->
-      <button id="menuBtn" onclick="toggleMenu()" class="inline-flex md:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
+      <button id="menuBtn" onclick="toggleMenu()" class="inline-flex lg:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-zinc-600">menu</span>
       </button>
       
@@ -1216,7 +1216,7 @@ kbd:hover{
         <span class="text-primary italic">Org Finder</span>
       </span>
       </a>
-      <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
+      <nav class="hidden lg:flex items-center gap-6 text-sm font-medium">
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#orgs" data-section="orgs">Organizations</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
@@ -1275,7 +1275,7 @@ kbd:hover{
 </header>
 
 <!-- Mobile Menu Overlay -->
-<div id="mobileMenu" class="fixed inset-0 z-50 hidden md:hidden" style="z-index:60;" role="dialog" aria-modal="true" aria-label="Navigation menu">
+<div id="mobileMenu" class="fixed inset-0 z-50 hidden lg:hidden" style="z-index:60;" role="dialog" aria-modal="true" aria-label="Navigation menu">
   <!-- Backdrop -->
   <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick="toggleMenu()" onkeydown="if(event.key==='Enter'||event.key===' ')toggleMenu()" tabindex="0" role="button" aria-label="Close menu"></div>
   
@@ -2318,7 +2318,7 @@ kbd:hover{
   // ══════════════════════════════════════════════
   // MOBILE MENU
   // ══════════════════════════════════════════════
-  const desktopNavMediaQuery = globalThis.matchMedia('(min-width: 768px)');
+  const desktopNavMediaQuery = globalThis.matchMedia('(min-width: 1024px)');
 
   function openMobileMenu(){
     const menu = document.getElementById('mobileMenu');

--- a/privacy.html
+++ b/privacy.html
@@ -49,7 +49,7 @@
   <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
     <div class="flex items-center gap-3">
       <!-- Mobile menu button -->
-      <button id="mobileMenuBtn" class="inline-flex md:hidden items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false">
+      <button id="mobileMenuBtn" class="inline-flex lg:hidden items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false">
         <span class="material-symbols-outlined text-zinc-600">menu</span>
       </button>
       <a href="index.html" class="flex items-center gap-2">
@@ -61,7 +61,7 @@
         </span>
       </a>
     </div>
-    <nav class="hidden md:flex items-center gap-6 text-sm font-medium" aria-label="Main navigation">
+    <nav class="hidden lg:flex items-center gap-6 text-sm font-medium" aria-label="Main navigation">
       <a href="index.html#orgs" class="text-zinc-600 hover:text-zinc-900 transition-colors">Organizations</a>
       <a href="index.html#guide" class="text-zinc-600 hover:text-zinc-900 transition-colors">Guide</a>
       <a href="index.html#issues" class="text-zinc-600 hover:text-zinc-900 transition-colors">Issues</a>
@@ -72,7 +72,7 @@
   </div>
 
   <!-- Mobile Menu -->
-  <div id="mobileMenu" class="hidden md:hidden border-t border-zinc-200 bg-white">
+  <div id="mobileMenu" class="hidden lg:hidden border-t border-zinc-200 bg-white">
     <nav class="flex flex-col px-4 py-3 gap-1" aria-label="Mobile navigation">
       <a href="index.html#orgs" class="flex items-center gap-3 px-3 py-2 rounded-lg text-zinc-700 hover:bg-zinc-100 text-sm font-medium transition-colors">
         <span class="material-symbols-outlined text-base">business</span> Organizations


### PR DESCRIPTION
## Closes #1918

### Description (program: GSSoC)

On iPad portrait (~768px), the desktop nav was kicking in too early. Nav items clipped and some were unreachable. Bumping the hamburger breakpoint from `md` (768px) to `lg` (1024px) takes care of it.

### What's New

- 📱 **Raised hamburger breakpoint:** Swapped `md:hidden` to `lg:hidden` on the hamburger button and desktop nav so the mobile menu kicks in at tablet portrait width.

  _To test: resize to ~768px or use DevTools iPad portrait. The hamburger should appear and all links should be reachable._

- 🔒 **Mobile menu overlay fix:** The `mobileMenu` overlay guard was also stuck at `md:hidden`. Changed it to `lg:hidden` so it doesn't bleed over the desktop nav above 1024px.

- 🖥️ **Media query updated:** Bumped `matchMedia` from `768px` to `1024px` to match the Tailwind classes.

- 🔗 **privacy.html:** Same breakpoint change, same fix.

### Screenshots (IPad)

**Before Fix 👇** 
<img width="1640" height="2360" alt="image" src="https://github.com/user-attachments/assets/f1d1a30d-81ee-46ec-98ff-c66995a95404" />


**After Fix 👇** 

<img width="889" height="1280" alt="image" src="https://github.com/user-attachments/assets/b8d28082-d736-4af8-aa73-db4b1d5810c6" />

### Files Changed

- `index.html` (5 additions, 5 deletions): hamburger button, desktop nav, mobile menu overlay, and media query breakpoint.
- `privacy.html` (3 additions, 3 deletions): same fix on the privacy page navbar.

### Type of Change

- [x] 🐛 Bug fix

### Checklist
- [x] related issue : #1918 
- [x] Desktop (≥1024px): desktop nav visible, no hamburger
- [x] Tablet portrait (~768px): hamburger menu visible, all links accessible
- [x] Mobile (<768px): hamburger menu visible
- [x] `privacy.html` navbar consistent with `index.html`
- [x] No new dependencies

💻 Environment
Browser: Safari
Device: iPad 10th gen (portrait orientation) / ~768px viewport
OS: IPadOS 26.5
