### PR TITLE
FEAT: Added optional count param to getRecommendations() + Show More button

### DIFF
--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -326,8 +326,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const showMoreHtml = (lastRecommendations.length > recs.length)
       ? `<div class="flex justify-center mt-6">
-           <button id="btnShowMoreRecs" class="px-5 py-2 rounded-full border border-zinc-200 dark:border-zinc-700 text-sm font-bold text-zinc-600 dark:text-zinc-300 hover:border-primary hover:text-primary transition-colors">
-             Show More
+           <button id="btnShowMoreRecs" aria-label="Show more recommendations" class="px-5 py-2 rounded-full border border-zinc-200 dark:border-zinc-700 text-sm font-bold text-zinc-600 dark:text-zinc-300 hover:border-primary hover:text-primary transition-colors">
+              Show More
            </button>
          </div>`
       : '';

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -9,7 +9,7 @@ let lastRecommendations = [];
 /**
  * Encapsulates the heavy analytical logic into a single async pipe.
  * Moved to outer scope to maximize reuse and minimize closure memory footprint.
- * 'count' defaults to Infinity here to fetch full recommendation list client-side.This allows UI to handle subsequent batching and rendering (like the 'Show More' functionality) entirely locally without re running the heavy analytical pipeline even though getRecommendations() inherently defaults to 6.
+ * Defaults count to Infinity so the full ranked list is fetched once and cached client side allowing ui to render orgs without re running the scoring pipeline.
  */
 async function analyzeProfile(username, resume, options = {}) {
   const { signal, count = Infinity } = options;
@@ -124,7 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const errorMsg = document.getElementById('aiErrorMsg');
   let visibleCount = 6;
 
-document.addEventListener('compareListChanged', () => {
+  document.addEventListener('compareListChanged', () => {
     const currentCompareList = globalThis.compareList || [];
     resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
       const card = btn.closest('[data-org-name]');
@@ -132,7 +132,7 @@ document.addEventListener('compareListChanged', () => {
       const isNowComparing = currentCompareList.includes(name);
       updateCompareVisualState(btn, card, isNowComparing);
     });
-});
+  });
 
   // Handle file upload
   if (fileUpload) {

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -9,6 +9,7 @@ let lastRecommendations = [];
 /**
  * Encapsulates the heavy analytical logic into a single async pipe.
  * Moved to outer scope to maximize reuse and minimize closure memory footprint.
+ * 'count' defaults to Infinity here to fetch full recommendation list client-side.This allows UI to handle subsequent batching and rendering (like the 'Show More' functionality) entirely locally without re running the heavy analytical pipeline even though getRecommendations() inherently defaults to 6.
  */
 async function analyzeProfile(username, resume, options = {}) {
   const { signal, count = Infinity } = options;
@@ -123,10 +124,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const errorMsg = document.getElementById('aiErrorMsg');
   let visibleCount = 6;
 
-  document.addEventListener('compareListChanged',() => {
-    if(lastRecommendations.length){
-      renderRecommendations(lastRecommendations.slice(0, visibleCount));
-    }
+ document.addEventListener('compareListChanged', () => {
+    const currentCompareList = globalThis.compareList || [];
+    resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
+      const card = btn.closest('[data-org-name]');
+      const name = btn.dataset.compareOrg;
+      const isNowComparing = currentCompareList.includes(name);
+      btn.classList.toggle('text-primary', isNowComparing);
+      btn.classList.toggle('text-zinc-400', !isNowComparing);
+      btn.innerHTML = isNowComparing
+        ? '<span class="material-symbols-outlined text-sm">check_circle</span> Comparing'
+        : '<span class="material-symbols-outlined text-sm">compare_arrows</span> Compare';
+      card?.classList.toggle('ring-2', isNowComparing);
+      card?.classList.toggle('ring-primary/30', isNowComparing);
+    });
   });
 
   // Handle file upload
@@ -281,7 +292,8 @@ document.addEventListener('DOMContentLoaded', () => {
       return `
       <article class="group relative bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up cursor-pointer flex flex-col ${inCompare ? 'ring-2 ring-primary/30' : ''}"
                data-org-name="${safeEscapeHtml(o.name)}"
-               data-org-index="${rec.orgIndex}">
+               data-org-index="${rec.orgIndex}"
+               tabindex="-1">
         
         <!-- Match Score Badge -->
         <div class="absolute top-0 right-0 bg-gradient-to-bl from-green-500 to-emerald-600 text-white px-3 py-1.5 rounded-bl-2xl rounded-tr-2xl font-bold text-xs shadow-sm flex items-center gap-1 z-10">

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -230,7 +230,9 @@ document.addEventListener('DOMContentLoaded', () => {
           newBtn.focus();
         } else {
           const cards = resultsContainer.querySelectorAll('article[data-org-name]');
-          cards[prevCount]?.focus();
+          const firstNewCard = cards[prevCount];
+          const focusTarget = firstNewCard?.querySelector('button') ?? firstNewCard;
+          focusTarget?.focus();
         }
         return;
       }

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -96,11 +96,8 @@ function handleCompareAction(e, btn, card) {
   // Core engine handles constraints and updates globalThis.compareList synchronously
   toggleCompare(e, name);
   
-  // Read the authoritative application state to govern local visual treatment
-  const currentCompareList = globalThis.compareList || [];
-  const isNowComparing = currentCompareList.includes(name);
-
-  updateCompareVisualState(btn, card, isNowComparing);
+  // Explicitly dispatch so compareListChanged listener syncs all card visual states
+  document.dispatchEvent(new CustomEvent('compareListChanged'));
 }
 
 function handleCardActivation(card) {
@@ -181,6 +178,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const requestId = ++currentRequestId;
 
     setAnalysisStateUI(true);
+    
     try {
       const recommendations = await analyzeProfile(username, resume, { signal });
       
@@ -211,6 +209,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Register one central delegate for all user actions triggered inside recommendation container
   if (resultsContainer) {
+    resultsContainer.addEventListener('keydown', (e) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      const card = e.target.closest('[data-org-name]');
+      if (card && e.target === card) {
+        e.preventDefault();
+        handleCardActivation(card);
+      }
+    });
+
     resultsContainer.addEventListener('click', (e) => {
       const target = e.target;
       
@@ -225,12 +232,37 @@ document.addEventListener('DOMContentLoaded', () => {
         return handleCompareAction(e, compareBtn, card);
       }
       
+      if (card) {
+        return handleCardActivation(card);
+      }
+
       const showMoreBtn = target.closest('#btnShowMoreRecs');
       if (showMoreBtn) {
         const prevCount = visibleCount;
-        visibleCount += 6;
-        renderRecommendations(lastRecommendations.slice(0, visibleCount));
-        const newBtn = resultsContainer.querySelector('#btnShowMoreRecs');
+        visibleCount = Math.min(visibleCount + 6, lastRecommendations.length);
+
+        const currentCompareList = globalThis.compareList || [];
+        const currentBookmarkedSet = globalThis.bookmarkedSet || new Set();
+        const newCardsHtml = lastRecommendations
+          .slice(prevCount, visibleCount)
+          .map(rec => buildCardHtml(rec, currentCompareList, currentBookmarkedSet))
+          .join('');
+
+        const grid = resultsContainer.querySelector('.grid');
+        if (grid) grid.insertAdjacentHTML('beforeend', newCardsHtml);
+
+        const oldShowMore = document.getElementById('btnShowMoreRecs')?.parentElement;
+        oldShowMore?.remove();
+        if (visibleCount < lastRecommendations.length) {
+          resultsContainer.insertAdjacentHTML('beforeend',
+            `<div class="flex justify-center mt-6">
+               <button id="btnShowMoreRecs" aria-label="Show more recommendations" class="px-5 py-2 rounded-full border border-zinc-200 dark:border-zinc-700 text-sm font-bold text-zinc-600 dark:text-zinc-300 hover:border-primary hover:text-primary transition-colors">
+                 Show More
+               </button>
+             </div>`);
+        }
+
+        const newBtn = document.getElementById('btnShowMoreRecs');
         if (newBtn) {
           newBtn.focus();
         } else {
@@ -241,11 +273,74 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         return;
       }
-
-      if (card) {
-        return handleCardActivation(card);
-      }
     });
+  }
+
+  function buildCardHtml(rec, currentCompareList, currentBookmarkedSet) {
+    const o = rec.org;
+    const githubOwner = o.github ? o.github.split('/')[0] : '';
+    const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
+
+    const inCompare = currentCompareList.includes(o.name);
+    const isBookmarked = typeof currentBookmarkedSet.has === 'function'
+      ? currentBookmarkedSet.has(o.name)
+      : false;
+
+    const reasonsHtml = rec.reasons.map(r =>
+      `<li class="text-[11px] text-zinc-600 dark:text-zinc-400 flex items-start gap-2"><span class="material-symbols-outlined text-xs text-emerald-500 mt-0.5">check_circle</span> <span class="leading-tight">${safeEscapeHtml(r)}</span></li>`
+    ).join('');
+
+    let matchedSkillsHtml = '';
+    if (rec.matchedSkills.length > 0) {
+      const skillsList = rec.matchedSkills.slice(0, 4).map(s =>
+        `<span class="px-2 py-0.5 bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 rounded text-[9px] font-bold uppercase tracking-wider">${safeEscapeHtml(s)}</span>`
+      ).join('');
+      matchedSkillsHtml = `<div class="mt-2 flex flex-wrap gap-1">${skillsList}</div>`;
+    }
+
+    const logoHtml = logoUrl
+      ? `<img src="${safeEscapeHtml(logoUrl)}" data-org-name="${safeEscapeHtml(o.name)}" alt="${safeEscapeHtml(o.name)} logo" class="w-full h-full object-contain rounded-lg" onerror="handleRecImgError(this, this.dataset.orgName)">
+         <div class="logo-placeholder hidden w-full h-full items-center justify-center text-primary font-bold text-xl font-headline bg-primary/5"></div>`
+      : `<div class="text-primary font-bold text-xl font-headline">${safeEscapeHtml(o.name[0] || '?')}</div>`;
+
+    return `
+    <article class="group relative bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up cursor-pointer flex flex-col ${inCompare ? 'ring-2 ring-primary/30' : ''}"
+             data-org-name="${safeEscapeHtml(o.name)}"
+             data-org-index="${rec.orgIndex}"
+             tabindex="-1">
+      <div class="absolute top-0 right-0 bg-gradient-to-bl from-green-500 to-emerald-600 text-white px-3 py-1.5 rounded-bl-2xl rounded-tr-2xl font-bold text-xs shadow-sm flex items-center gap-1 z-10">
+        <span class="material-symbols-outlined text-sm">target</span> ${rec.score}% Match
+      </div>
+      <div class="flex justify-between items-start mb-4 pt-2">
+        <div class="w-14 h-14 rounded-xl bg-surface-container-low dark:bg-zinc-800 flex items-center justify-center p-2 overflow-hidden">
+          ${logoHtml}
+        </div>
+        <div class="flex items-center gap-2 mt-2">
+           <button class="bookmark-btn ${isBookmarked ? 'active text-orange-500' : 'text-zinc-300'}"
+                   data-bookmark-org="${safeEscapeHtml(o.name)}"
+                   title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">
+              <span class="material-symbols-outlined text-xl ${isBookmarked ? 'icon-fill' : ''}">star</span>
+           </button>
+        </div>
+      </div>
+      <div class="flex-1">
+        <h3 class="font-headline text-lg font-bold text-zinc-900 dark:text-zinc-100 mb-1 group-hover:text-primary transition-colors">${safeEscapeHtml(o.name)}</h3>
+        <span class="category-tag inline-block mb-3">${safeEscapeHtml((o.cat || 'Other').toUpperCase())}</span>
+        <p class="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed mb-3 line-clamp-2">${safeEscapeHtml(o.desc || '')}</p>
+        <div class="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800">
+          <ul class="space-y-1.5 mb-3">${reasonsHtml}</ul>
+          ${matchedSkillsHtml}
+        </div>
+      </div>
+      <div class="flex items-center justify-between pt-4 mt-4 border-t border-zinc-100 dark:border-zinc-800">
+        <button data-compare-org="${safeEscapeHtml(o.name)}" class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest ${inCompare ? 'text-primary' : 'text-zinc-400'} hover:text-primary transition-colors">
+          <span class="material-symbols-outlined text-sm">${inCompare ? 'check_circle' : 'compare_arrows'}</span> ${inCompare ? 'Comparing' : 'Compare'}
+        </button>
+        <button class="flex items-center gap-1 text-primary font-bold text-xs uppercase tracking-widest group-hover:gap-2 transition-all">
+          View <span class="material-symbols-outlined text-sm">arrow_forward</span>
+        </button>
+      </div>
+    </article>`;
   }
 
   function renderRecommendations(recs) {
@@ -257,87 +352,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const currentCompareList = globalThis.compareList || [];
     const currentBookmarkedSet = globalThis.bookmarkedSet || new Set();
 
-    const html = recs.map(rec => {
-      const o = rec.org;
-      const githubOwner = o.github ? o.github.split('/')[0] : '';
-      const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
-      
-      const inCompare = currentCompareList.includes(o.name);
-      const isBookmarked = typeof currentBookmarkedSet.has === 'function' 
-        ? currentBookmarkedSet.has(o.name) 
-        : false;
-      
-      const reasonsHtml = rec.reasons.map(r => `<li class="text-[11px] text-zinc-600 dark:text-zinc-400 flex items-start gap-2"><span class="material-symbols-outlined text-xs text-emerald-500 mt-0.5">check_circle</span> <span class="leading-tight">${safeEscapeHtml(r)}</span></li>`).join('');
-      
-      let matchedSkillsHtml = '';
-      if (rec.matchedSkills.length > 0) {
-         const skillsList = rec.matchedSkills.slice(0, 4).map(s => `<span class="px-2 py-0.5 bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 rounded text-[9px] font-bold uppercase tracking-wider">${safeEscapeHtml(s)}</span>`).join('');
-         matchedSkillsHtml = `<div class="mt-2 flex flex-wrap gap-1">${skillsList}</div>`;
-      }
-
-
-      // Defined explicitly outside string to eliminate linting issues with nested template literals
-      const logoHtml = logoUrl 
-        ? `<img src="${safeEscapeHtml(logoUrl)}" data-org-name="${safeEscapeHtml(o.name)}" alt="${safeEscapeHtml(o.name)} logo" class="w-full h-full object-contain rounded-lg" onerror="handleRecImgError(this, this.dataset.orgName)">
-           <div class="logo-placeholder hidden w-full h-full items-center justify-center text-primary font-bold text-xl font-headline bg-primary/5"></div>`
-        : `<div class="text-primary font-bold text-xl font-headline">${safeEscapeHtml(o.name[0] || '?')}</div>`;
-
-
-      return `
-      <article class="group relative bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up cursor-pointer flex flex-col ${inCompare ? 'ring-2 ring-primary/30' : ''}"
-               data-org-name="${safeEscapeHtml(o.name)}"
-               data-org-index="${rec.orgIndex}"
-               tabindex="-1">
-        
-        <!-- Match Score Badge -->
-        <div class="absolute top-0 right-0 bg-gradient-to-bl from-green-500 to-emerald-600 text-white px-3 py-1.5 rounded-bl-2xl rounded-tr-2xl font-bold text-xs shadow-sm flex items-center gap-1 z-10">
-          <span class="material-symbols-outlined text-sm">target</span> ${rec.score}% Match
-        </div>
-
-        <!-- Header: Logo & Bookmarking -->
-        <div class="flex justify-between items-start mb-4 pt-2">
-          <div class="w-14 h-14 rounded-xl bg-surface-container-low dark:bg-zinc-800 flex items-center justify-center p-2 overflow-hidden">
-            ${logoHtml}
-          </div>
-          
-          <div class="flex items-center gap-2 mt-2">
-             <button class="bookmark-btn ${isBookmarked ? 'active text-orange-500' : 'text-zinc-300'}" 
-                     data-bookmark-org="${safeEscapeHtml(o.name)}" 
-                     title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">
-                <span class="material-symbols-outlined text-xl ${isBookmarked ? 'icon-fill' : ''}">star</span>
-             </button>
-          </div>
-        </div>
-
-        <!-- Body Text & Category -->
-        <div class="flex-1">
-          <h3 class="font-headline text-lg font-bold text-zinc-900 dark:text-zinc-100 mb-1 group-hover:text-primary transition-colors">${safeEscapeHtml(o.name)}</h3>
-          <span class="category-tag inline-block mb-3">${safeEscapeHtml((o.cat || 'Other').toUpperCase())}</span>
-          
-          <p class="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed mb-3 line-clamp-2">${safeEscapeHtml(o.desc || '')}</p>
-
-          <!-- Insights Box -->
-          <div class="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800">
-            <ul class="space-y-1.5 mb-3">
-              ${reasonsHtml}
-            </ul>
-            ${matchedSkillsHtml}
-          </div>
-        </div>
-
-        <!-- Bottom: Action Bar -->
-        <div class="flex items-center justify-between pt-4 mt-4 border-t border-zinc-100 dark:border-zinc-800">
-          <button data-compare-org="${safeEscapeHtml(o.name)}" class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest ${inCompare ? 'text-primary' : 'text-zinc-400'} hover:text-primary transition-colors">
-            <span class="material-symbols-outlined text-sm">${inCompare ? 'check_circle' : 'compare_arrows'}</span> ${inCompare ? 'Comparing' : 'Compare'}
-          </button>
-          
-          <button class="flex items-center gap-1 text-primary font-bold text-xs uppercase tracking-widest group-hover:gap-2 transition-all">
-            View <span class="material-symbols-outlined text-sm">arrow_forward</span>
-          </button>
-        </div>
-      </article>
-      `;
-    }).join('');
+    const html = recs.map(rec => buildCardHtml(rec, currentCompareList, currentBookmarkedSet)).join('');
 
     const showMoreHtml = (lastRecommendations.length > recs.length)
       ? `<div class="flex justify-center mt-6">

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -224,6 +224,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (showMoreBtn) {
         visibleCount += 6;
         renderRecommendations(lastRecommendations.slice(0, visibleCount));
+        resultsContainer.querySelector('#btnShowMoreRecs')?.focus();
         return;
       }
 

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -11,7 +11,7 @@ let lastRecommendations = [];
  * Moved to outer scope to maximize reuse and minimize closure memory footprint.
  */
 async function analyzeProfile(username, resume, options = {}) {
-  const { signal, count = 6 } = options;
+  const { signal, count = Infinity } = options;
   let githubProfile = null;
   let skills = [];
 
@@ -177,7 +177,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     setAnalysisStateUI(true);
     try {
-      const recommendations = await analyzeProfile(username, resume, { signal, count: Infinity });
+      const recommendations = await analyzeProfile(username, resume, { signal });
       
       if (requestId !== currentRequestId) return;
       
@@ -222,9 +222,16 @@ document.addEventListener('DOMContentLoaded', () => {
       
       const showMoreBtn = target.closest('#btnShowMoreRecs');
       if (showMoreBtn) {
+        const prevCount = visibleCount;
         visibleCount += 6;
         renderRecommendations(lastRecommendations.slice(0, visibleCount));
-        resultsContainer.querySelector('#btnShowMoreRecs')?.focus();
+        const newBtn = resultsContainer.querySelector('#btnShowMoreRecs');
+        if (newBtn) {
+          newBtn.focus();
+        } else {
+          const cards = resultsContainer.querySelectorAll('article[data-org-name]');
+          cards[prevCount]?.focus();
+        }
         return;
       }
 

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -88,7 +88,7 @@ function updateCompareVisualState(btn, card, isNowComparing) {
   card?.classList.toggle('ring-primary/30', isNowComparing);
 }
 
-function handleCompareAction(e, btn, card) {
+function handleCompareAction(e, btn) {
   e.stopPropagation();
   const name = btn.dataset.compareOrg;
   if (typeof toggleCompare !== 'function') return;
@@ -106,6 +106,74 @@ function handleCardActivation(card) {
     openModal(idx);
   }
 }
+
+function buildCardHtml(rec, currentCompareList, currentBookmarkedSet) {
+    const o = rec.org;
+    const githubOwner = o.github ? o.github.split('/')[0] : '';
+    const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
+
+    const inCompare = currentCompareList.includes(o.name);
+    const isBookmarked = typeof currentBookmarkedSet.has === 'function'
+      ? currentBookmarkedSet.has(o.name)
+      : false;
+
+    const reasonsHtml = rec.reasons.map(r =>
+      `<li class="text-[11px] text-zinc-600 dark:text-zinc-400 flex items-start gap-2"><span class="material-symbols-outlined text-xs text-emerald-500 mt-0.5">check_circle</span> <span class="leading-tight">${safeEscapeHtml(r)}</span></li>`
+    ).join('');
+
+    let matchedSkillsHtml = '';
+    if (rec.matchedSkills.length > 0) {
+      const skillsList = rec.matchedSkills.slice(0, 4).map(s =>
+        `<span class="px-2 py-0.5 bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 rounded text-[9px] font-bold uppercase tracking-wider">${safeEscapeHtml(s)}</span>`
+      ).join('');
+      matchedSkillsHtml = `<div class="mt-2 flex flex-wrap gap-1">${skillsList}</div>`;
+    }
+
+    const logoHtml = logoUrl
+      ? `<img src="${safeEscapeHtml(logoUrl)}" data-org-name="${safeEscapeHtml(o.name)}" alt="${safeEscapeHtml(o.name)} logo" class="w-full h-full object-contain rounded-lg" onerror="handleRecImgError(this, this.dataset.orgName)">
+         <div class="logo-placeholder hidden w-full h-full items-center justify-center text-primary font-bold text-xl font-headline bg-primary/5"></div>`
+      : `<div class="text-primary font-bold text-xl font-headline">${safeEscapeHtml(o.name[0] || '?')}</div>`;
+
+    return `
+    <article class="group relative bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up cursor-pointer flex flex-col ${inCompare ? 'ring-2 ring-primary/30' : ''}"
+             data-org-name="${safeEscapeHtml(o.name)}"
+             data-org-index="${rec.orgIndex}"
+             tabindex="-1">
+      <div class="absolute top-0 right-0 bg-gradient-to-bl from-green-500 to-emerald-600 text-white px-3 py-1.5 rounded-bl-2xl rounded-tr-2xl font-bold text-xs shadow-sm flex items-center gap-1 z-10">
+        <span class="material-symbols-outlined text-sm">target</span> ${rec.score}% Match
+      </div>
+      <div class="flex justify-between items-start mb-4 pt-2">
+        <div class="w-14 h-14 rounded-xl bg-surface-container-low dark:bg-zinc-800 flex items-center justify-center p-2 overflow-hidden">
+          ${logoHtml}
+        </div>
+        <div class="flex items-center gap-2 mt-2">
+           <button class="bookmark-btn ${isBookmarked ? 'active text-orange-500' : 'text-zinc-300'}"
+                   data-bookmark-org="${safeEscapeHtml(o.name)}"
+                   title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">
+              <span class="material-symbols-outlined text-xl ${isBookmarked ? 'icon-fill' : ''}">star</span>
+           </button>
+        </div>
+      </div>
+      <div class="flex-1">
+        <h3 class="font-headline text-lg font-bold text-zinc-900 dark:text-zinc-100 mb-1 group-hover:text-primary transition-colors">${safeEscapeHtml(o.name)}</h3>
+        <span class="category-tag inline-block mb-3">${safeEscapeHtml((o.cat || 'Other').toUpperCase())}</span>
+        <p class="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed mb-3 line-clamp-2">${safeEscapeHtml(o.desc || '')}</p>
+        <div class="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800">
+          <ul class="space-y-1.5 mb-3">${reasonsHtml}</ul>
+          ${matchedSkillsHtml}
+        </div>
+      </div>
+      <div class="flex items-center justify-between pt-4 mt-4 border-t border-zinc-100 dark:border-zinc-800">
+        <button data-compare-org="${safeEscapeHtml(o.name)}" class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest ${inCompare ? 'text-primary' : 'text-zinc-400'} hover:text-primary transition-colors">
+          <span class="material-symbols-outlined text-sm">${inCompare ? 'check_circle' : 'compare_arrows'}</span> ${inCompare ? 'Comparing' : 'Compare'}
+        </button>
+        <button class="flex items-center gap-1 text-primary font-bold text-xs uppercase tracking-widest group-hover:gap-2 transition-all">
+          View <span class="material-symbols-outlined text-sm">arrow_forward</span>
+        </button>
+      </div>
+    </article>`;
+}
+
 
 document.addEventListener('DOMContentLoaded', () => {
   const getRecsBtn = document.getElementById('btnGetRecommendations');
@@ -178,7 +246,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const requestId = ++currentRequestId;
 
     setAnalysisStateUI(true);
-    
     try {
       const recommendations = await analyzeProfile(username, resume, { signal });
       
@@ -229,7 +296,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const compareBtn = target.closest('[data-compare-org]');
       const card = target.closest('[data-org-name]');
       if (compareBtn && card) {
-        return handleCompareAction(e, compareBtn, card);
+        return handleCompareAction(e, compareBtn);
       }
       
       if (card) {
@@ -275,74 +342,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-
-  function buildCardHtml(rec, currentCompareList, currentBookmarkedSet) {
-    const o = rec.org;
-    const githubOwner = o.github ? o.github.split('/')[0] : '';
-    const logoUrl = githubOwner ? `https://github.com/${githubOwner}.png?size=80` : '';
-
-    const inCompare = currentCompareList.includes(o.name);
-    const isBookmarked = typeof currentBookmarkedSet.has === 'function'
-      ? currentBookmarkedSet.has(o.name)
-      : false;
-
-    const reasonsHtml = rec.reasons.map(r =>
-      `<li class="text-[11px] text-zinc-600 dark:text-zinc-400 flex items-start gap-2"><span class="material-symbols-outlined text-xs text-emerald-500 mt-0.5">check_circle</span> <span class="leading-tight">${safeEscapeHtml(r)}</span></li>`
-    ).join('');
-
-    let matchedSkillsHtml = '';
-    if (rec.matchedSkills.length > 0) {
-      const skillsList = rec.matchedSkills.slice(0, 4).map(s =>
-        `<span class="px-2 py-0.5 bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 rounded text-[9px] font-bold uppercase tracking-wider">${safeEscapeHtml(s)}</span>`
-      ).join('');
-      matchedSkillsHtml = `<div class="mt-2 flex flex-wrap gap-1">${skillsList}</div>`;
-    }
-
-    const logoHtml = logoUrl
-      ? `<img src="${safeEscapeHtml(logoUrl)}" data-org-name="${safeEscapeHtml(o.name)}" alt="${safeEscapeHtml(o.name)} logo" class="w-full h-full object-contain rounded-lg" onerror="handleRecImgError(this, this.dataset.orgName)">
-         <div class="logo-placeholder hidden w-full h-full items-center justify-center text-primary font-bold text-xl font-headline bg-primary/5"></div>`
-      : `<div class="text-primary font-bold text-xl font-headline">${safeEscapeHtml(o.name[0] || '?')}</div>`;
-
-    return `
-    <article class="group relative bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up cursor-pointer flex flex-col ${inCompare ? 'ring-2 ring-primary/30' : ''}"
-             data-org-name="${safeEscapeHtml(o.name)}"
-             data-org-index="${rec.orgIndex}"
-             tabindex="-1">
-      <div class="absolute top-0 right-0 bg-gradient-to-bl from-green-500 to-emerald-600 text-white px-3 py-1.5 rounded-bl-2xl rounded-tr-2xl font-bold text-xs shadow-sm flex items-center gap-1 z-10">
-        <span class="material-symbols-outlined text-sm">target</span> ${rec.score}% Match
-      </div>
-      <div class="flex justify-between items-start mb-4 pt-2">
-        <div class="w-14 h-14 rounded-xl bg-surface-container-low dark:bg-zinc-800 flex items-center justify-center p-2 overflow-hidden">
-          ${logoHtml}
-        </div>
-        <div class="flex items-center gap-2 mt-2">
-           <button class="bookmark-btn ${isBookmarked ? 'active text-orange-500' : 'text-zinc-300'}"
-                   data-bookmark-org="${safeEscapeHtml(o.name)}"
-                   title="${isBookmarked ? 'Remove bookmark' : 'Add bookmark'}">
-              <span class="material-symbols-outlined text-xl ${isBookmarked ? 'icon-fill' : ''}">star</span>
-           </button>
-        </div>
-      </div>
-      <div class="flex-1">
-        <h3 class="font-headline text-lg font-bold text-zinc-900 dark:text-zinc-100 mb-1 group-hover:text-primary transition-colors">${safeEscapeHtml(o.name)}</h3>
-        <span class="category-tag inline-block mb-3">${safeEscapeHtml((o.cat || 'Other').toUpperCase())}</span>
-        <p class="text-zinc-600 dark:text-zinc-400 text-sm leading-relaxed mb-3 line-clamp-2">${safeEscapeHtml(o.desc || '')}</p>
-        <div class="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800">
-          <ul class="space-y-1.5 mb-3">${reasonsHtml}</ul>
-          ${matchedSkillsHtml}
-        </div>
-      </div>
-      <div class="flex items-center justify-between pt-4 mt-4 border-t border-zinc-100 dark:border-zinc-800">
-        <button data-compare-org="${safeEscapeHtml(o.name)}" class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest ${inCompare ? 'text-primary' : 'text-zinc-400'} hover:text-primary transition-colors">
-          <span class="material-symbols-outlined text-sm">${inCompare ? 'check_circle' : 'compare_arrows'}</span> ${inCompare ? 'Comparing' : 'Compare'}
-        </button>
-        <button class="flex items-center gap-1 text-primary font-bold text-xs uppercase tracking-widest group-hover:gap-2 transition-all">
-          View <span class="material-symbols-outlined text-sm">arrow_forward</span>
-        </button>
-      </div>
-    </article>`;
-  }
-
+  
+  
   function renderRecommendations(recs) {
     if (!recs || recs.length === 0) {
       showError("Could not find any matching organizations based on your profile.");

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -78,6 +78,16 @@ function handleBookmarkAction(e, btn) {
   }
 }
 
+function updateCompareVisualState(btn, card, isNowComparing) {
+  btn.classList.toggle('text-primary', isNowComparing);
+  btn.classList.toggle('text-zinc-400', !isNowComparing);
+  btn.innerHTML = isNowComparing
+    ? '<span class="material-symbols-outlined text-sm">check_circle</span> Comparing'
+    : '<span class="material-symbols-outlined text-sm">compare_arrows</span> Compare';
+  card?.classList.toggle('ring-2', isNowComparing);
+  card?.classList.toggle('ring-primary/30', isNowComparing);
+}
+
 function handleCompareAction(e, btn, card) {
   e.stopPropagation();
   const name = btn.dataset.compareOrg;
@@ -90,17 +100,7 @@ function handleCompareAction(e, btn, card) {
   const currentCompareList = globalThis.compareList || [];
   const isNowComparing = currentCompareList.includes(name);
 
-  if (isNowComparing) {
-     btn.classList.add('text-primary');
-     btn.classList.remove('text-zinc-400');
-     btn.innerHTML = '<span class="material-symbols-outlined text-sm">check_circle</span> Comparing';
-     card.classList.add('ring-2', 'ring-primary/30');
-  } else {
-     btn.classList.remove('text-primary');
-     btn.classList.add('text-zinc-400');
-     btn.innerHTML = '<span class="material-symbols-outlined text-sm">compare_arrows</span> Compare';
-     card.classList.remove('ring-2', 'ring-primary/30');
-  }
+  updateCompareVisualState(btn, card, isNowComparing);
 }
 
 function handleCardActivation(card) {
@@ -124,21 +124,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const errorMsg = document.getElementById('aiErrorMsg');
   let visibleCount = 6;
 
- document.addEventListener('compareListChanged', () => {
+document.addEventListener('compareListChanged', () => {
     const currentCompareList = globalThis.compareList || [];
     resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
       const card = btn.closest('[data-org-name]');
       const name = btn.dataset.compareOrg;
       const isNowComparing = currentCompareList.includes(name);
-      btn.classList.toggle('text-primary', isNowComparing);
-      btn.classList.toggle('text-zinc-400', !isNowComparing);
-      btn.innerHTML = isNowComparing
-        ? '<span class="material-symbols-outlined text-sm">check_circle</span> Comparing'
-        : '<span class="material-symbols-outlined text-sm">compare_arrows</span> Compare';
-      card?.classList.toggle('ring-2', isNowComparing);
-      card?.classList.toggle('ring-primary/30', isNowComparing);
+      updateCompareVisualState(btn, card, isNowComparing);
     });
-  });
+});
 
   // Handle file upload
   if (fileUpload) {

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -11,7 +11,7 @@ let lastRecommendations = [];
  * Moved to outer scope to maximize reuse and minimize closure memory footprint.
  */
 async function analyzeProfile(username, resume, options = {}) {
-  const { signal } = options;
+  const { signal, count = 6 } = options;
   let githubProfile = null;
   let skills = [];
 
@@ -29,7 +29,7 @@ async function analyzeProfile(username, resume, options = {}) {
     skills = extractSkills(resume);
   }
 
-  return getRecommendations(skills, githubProfile);
+  return getRecommendations(skills, githubProfile, count);
 }
 
 /**
@@ -121,10 +121,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const errorState = document.getElementById('aiErrorState');
   const resultsContainer = document.getElementById('aiResultsContainer');
   const errorMsg = document.getElementById('aiErrorMsg');
+  let visibleCount = 6;
 
   document.addEventListener('compareListChanged',() => {
     if(lastRecommendations.length){
-      renderRecommendations(lastRecommendations);
+      renderRecommendations(lastRecommendations.slice(0, visibleCount));
     }
   });
 
@@ -176,12 +177,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     setAnalysisStateUI(true);
     try {
-      const recommendations = await analyzeProfile(username, resume, { signal });
+      const recommendations = await analyzeProfile(username, resume, { signal, count: Infinity });
       
       if (requestId !== currentRequestId) return;
       
-      lastRecommendations = recommendations; 
-      renderRecommendations(recommendations);
+      lastRecommendations = recommendations;
+      visibleCount = 6;
+      renderRecommendations(recommendations.slice(0, visibleCount));
     } catch (err) {
       if (requestId !== currentRequestId || err.name === 'AbortError') return;
       showError(err.message || "An unexpected error occurred during analysis.");
@@ -218,6 +220,13 @@ document.addEventListener('DOMContentLoaded', () => {
         return handleCompareAction(e, compareBtn, card);
       }
       
+      const showMoreBtn = target.closest('#btnShowMoreRecs');
+      if (showMoreBtn) {
+        visibleCount += 6;
+        renderRecommendations(lastRecommendations.slice(0, visibleCount));
+        return;
+      }
+
       if (card) {
         return handleCardActivation(card);
       }
@@ -314,6 +323,14 @@ document.addEventListener('DOMContentLoaded', () => {
       `;
     }).join('');
 
-    resultsContainer.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">${html}</div>`;
+    const showMoreHtml = (lastRecommendations.length > recs.length)
+      ? `<div class="flex justify-center mt-6">
+           <button id="btnShowMoreRecs" class="px-5 py-2 rounded-full border border-zinc-200 dark:border-zinc-700 text-sm font-bold text-zinc-600 dark:text-zinc-300 hover:border-primary hover:text-primary transition-colors">
+             Show More
+           </button>
+         </div>`
+      : '';
+
+    resultsContainer.innerHTML = `<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">${html}</div>${showMoreHtml}`;
   }
 });

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -338,7 +338,6 @@ document.addEventListener('DOMContentLoaded', () => {
           const focusTarget = firstNewCard?.querySelector('button') ?? firstNewCard;
           focusTarget?.focus();
         }
-        return;
       }
     });
   }

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -9,7 +9,7 @@
  * @param {Object|null} githubProfile - Optional GitHub profile metrics
  * @returns {Array<Object>} - Top 6 recommended organizations sorted by score
  */
-function getRecommendations(resumeSkills = [], githubProfile = null) {
+function getRecommendations(resumeSkills = [], githubProfile = null, count = 6) {
   if (typeof ORGS === 'undefined' || !Array.isArray(ORGS)) {
     console.error("ORGS is not defined.");
     return [];
@@ -35,7 +35,7 @@ function getRecommendations(resumeSkills = [], githubProfile = null) {
   );
   
   scoredOrgs.sort((a, b) => b.rawScore - a.rawScore);
-  return scoredOrgs.slice(0, 6);
+  return scoredOrgs.slice(0, count);
 }
 
 function calculateLanguageScore(userLanguages, orgTags, orgCat, matchedSkills, matchReasons) {

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -18,7 +18,7 @@ function getRecommendations(resumeSkills = [], githubProfile = null, count = 6) 
   }
   
   const parsed = Number(count);
-  const safeCount = ( !Number.isNaN(parsed) && parsed > 0) ? parsed : 6;
+  const safeCount = ( !Number.isNaN(parsed) && parsed > 0) ? Math.floor(parsed) : 6;
 
   const normalize = globalThis.normalizeSkill || (s => s);
   const userLanguages = new Set();

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -3,11 +3,13 @@
 /* global ORGS */
 
 /**
- * Retrieves the top 6 recommended organizations based on skills and profile.
+ * Retrieves recommended organizations based on skills and profile.
  * 
  * @param {Array<string>} resumeSkills - Unique set of extracted resume skills
  * @param {Object|null} githubProfile - Optional GitHub profile metrics
- * @returns {Array<Object>} - Top 6 recommended organizations sorted by score
+ * @param {number} [count=6] - Maximum number of organizations to return.
+ *   Pass Infinity to return all scored orgs. Negative numbers, NaN, null and non numeric values fall back to the default of 6.
+ * @returns {Array<Object>} - Recommended organizations sorted by score
  */
 function getRecommendations(resumeSkills = [], githubProfile = null, count = 6) {
   if (typeof ORGS === 'undefined' || !Array.isArray(ORGS)) {
@@ -15,7 +17,8 @@ function getRecommendations(resumeSkills = [], githubProfile = null, count = 6) 
     return [];
   }
   
-  const safeCount = (typeof count === 'number' && !isNaN(count) && count > 0) ? count : 6;
+  const parsed = Number(count);
+  const safeCount = ( !Number.isNaN(parsed) && parsed > 0) ? parsed : 6;
 
   const normalize = globalThis.normalizeSkill || (s => s);
   const userLanguages = new Set();

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -14,6 +14,8 @@ function getRecommendations(resumeSkills = [], githubProfile = null, count = 6) 
     console.error("ORGS is not defined.");
     return [];
   }
+  
+  const safeCount = (typeof count === 'number' && !isNaN(count) && count > 0) ? count : 6;
 
   const normalize = globalThis.normalizeSkill || (s => s);
   const userLanguages = new Set();
@@ -35,7 +37,7 @@ function getRecommendations(resumeSkills = [], githubProfile = null, count = 6) 
   );
   
   scoredOrgs.sort((a, b) => b.rawScore - a.rawScore);
-  return scoredOrgs.slice(0, count);
+  return scoredOrgs.slice(0, safeCount);
 }
 
 function calculateLanguageScore(userLanguages, orgTags, orgCat, matchedSkills, matchReasons) {


### PR DESCRIPTION
## 📝 Description
getRecommendations() now takes an optional count param (default 6, fully backward compatible). recommendation-ui.js fetches the full ranked list once per search, caches it & reveals more results via Show More button instead of re-fetching on every click.

Also fixes a latent bug where the compareListChanged listener re-rendered the entire cached list instead of respecting the currently visible count.

## 🔗 Related Issue
Closes #1864

## 🚀 Program Classification
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [x] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test

1. Open index.html in a browser
2. Go to [AI Recommender](http://localhost:8000/#ai-recommender) section
3. Enter a few skills & GitHub username and click Get Recommendations - confirm exactly 6 cards render ( previous default behavior)
4. Scroll down and confirm Show More button appears below the results (only if more than 6 matching orgs exist)
5. Click Show More - confirm 6 additional cards are appended without a new network/API call being triggered
6. Keep clicking Show More until all matching orgs are shown - confirm the button disappears once there's nothing left to reveal.

## 📸 Screenshots (if applicable)
<img width="1915" height="946" alt="image" src="https://github.com/user-attachments/assets/4ccbe24c-de60-4298-a4b6-d895f2311db3" />
<img width="1916" height="947" alt="image" src="https://github.com/user-attachments/assets/c4b27489-b33d-45ff-afbf-100e046f1a5f" />

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

