### PR TITLE
fix: switch vercel.json from rewrites to routes to fix '/' routing pr…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,6 @@
   "routes": [
     { "src": "/app/(.*)", "dest": "/index.html" },
     { "src": "/app", "dest": "/index.html" },
-    { "src": "/api/github", "dest": "/api/github.js" },
     {
       "src": "/api/(.*)",
       "headers": {
@@ -23,7 +22,7 @@
       },
       "continue": true
     },
-    { "src": "/", "dest": "/landing.html" },
-    { "handle": "filesystem" }
+    { "src": "/api/github", "dest": "/api/github.js" },
+    { "src": "/", "dest": "/landing.html" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,25 +4,26 @@
   "outputDirectory": ".",
   "buildCommand": "",
   "devCommand": "npx serve . -l $PORT",
-  "rewrites": [
-    { "source": "/", "destination": "/landing.html" },
-    { "source": "/app", "destination": "/index.html" },
-    { "source": "/app/:path*", "destination": "/index.html" },
-    { "source": "/api/github", "destination": "/api/github.js" }
-  ],
-  "headers": [
+  "routes": [
+    { "src": "/app/(.*)", "dest": "/index.html" },
+    { "src": "/app", "dest": "/index.html" },
+    { "src": "/api/github", "dest": "/api/github.js" },
     {
-      "source": "/api/(.*)",
-      "headers": [
-        { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Cache-Control", "value": "s-maxage=3600" }
-      ]
+      "src": "/api/(.*)",
+      "headers": {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "s-maxage=3600"
+      },
+      "continue": true
     },
     {
-      "source": "/data/(.*)\\.json",
-      "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
-      ]
-    }
+      "src": "/data/(.*)\\.json",
+      "headers": {
+        "Cache-Control": "public, max-age=0, must-revalidate"
+      },
+      "continue": true
+    },
+    { "src": "/", "dest": "/landing.html" },
+    { "handle": "filesystem" }
   ]
 }


### PR DESCRIPTION
## 📝 Description
Fixes routing so "/" and "/app" correctly serve landing.html and index.html respectively. 

Previously, both routes served index.html because Vercel's default static-file handling for index.html took precedence over the "rewrites" rule for "/" — since both index.html and landing.html exist at the repo root. 

Switched vercel.json from "rewrites" to the legacy "routes" array, which allows explicit ordering so the route for "/" is evaluated before Vercel's filesystem fallback ({ "handle": "filesystem" }).

## 🔗 Related Issue
Closes #1981 

## 🚀 Program Classification
- [x] GSSoC26

## 🔄 Type of Change
- [x] 🐛 Bug fix

## 🧪 How to Test
1. Deploy this branch to Vercel 
2. Visit "/" — should show landing.html (the marketing page)
3. Visit "/app" — should show index.html (the dashboard)
4. Visit "/app/anything" — should still resolve to index.html
5. Confirm /api/github and /data/*.json headers still work as before

## 📸 Screen Recording after Fix:

https://github.com/user-attachments/assets/3c4d7ff3-16d1-48fd-9d01-e50be00efd40


## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

