### PR TITLE
fix(perf): debounce search input to prevent excessive filter re-renders

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -49,6 +49,22 @@ const CATEGORY_META = {
   other: { className: 'bg-zinc-100 text-zinc-600', label: 'Other' },
 };
 
+// ══════════════════════════════════════════════
+// UTILITY FUNCTIONS
+// ══════════════════════════════════════════════
+/**
+ * Returns a debounced version of fn that delays invoking it until after
+ * `delay` ms have elapsed since the last call. Prevents excessive filter
+ * re-renders on every keystroke in search inputs.
+ */
+function debounce(fn, delay) {
+  let timer;
+  return function (...args) {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn.apply(this, args), delay);
+  };
+}
+
 const LANGUAGE_ALIASES = {
   'python': ['python'],
   'javascript': ['javascript', 'js'],
@@ -2463,11 +2479,13 @@ document.addEventListener('DOMContentLoaded', () => {
   renderGoodFirstIssues();
 
   // Wire up filter event listeners
-  document.getElementById('searchInput')?.addEventListener('input', applyFilters);
+  const debouncedApplyFilters = debounce(applyFilters, 300);
+  document.getElementById('searchInput')?.addEventListener('input', debouncedApplyFilters);
   document.getElementById('categoryFilter')?.addEventListener('change', applyFilters);
   document.getElementById('complexityFilter')?.addEventListener('change', applyFilters);
   document.getElementById('sortSelect')?.addEventListener('change', applyFilters);
-  document.getElementById('mentorSearchInput')?.addEventListener('input', renderMentorFinder);
+  const debouncedRenderMentorFinder = debounce(renderMentorFinder, 300);
+  document.getElementById('mentorSearchInput')?.addEventListener('input', debouncedRenderMentorFinder);
   document.getElementById('mentorChannelFilter')?.addEventListener('change', renderMentorFinder);
   document.getElementById('matchAllLanguagesToggle')?.addEventListener('change', (e) => {
     matchAllLanguages = e.target.checked;
@@ -2518,7 +2536,7 @@ document.addEventListener('DOMContentLoaded', () => {
         searchInput.value = e.target.value;
         const orgsSec = document.getElementById('orgs');
         if (orgsSec) orgsSec.scrollIntoView({ behavior: 'smooth' });
-        applyFilters();
+        debouncedApplyFilters();
       }
     });
   }


### PR DESCRIPTION
## Description

The organization search input and mentor search input triggered a full filter/render operation on every single keystroke without debouncing, causing 15+ synchronous filter operations when typing a typical search query, resulting in UI sluggishness and unnecessary DOM thrashing.

## Root Cause

The `input` event listeners for `searchInput` and `mentorSearchInput` called `applyFilters` / `renderMentorFinder` directly with no debounce wrapper.

## Fix

- Added a small `debounce(fn, delay)` utility function.
- Wrapped the `searchInput` listener (and the synced `hero-search` input) with a 300ms debounced call to `applyFilters`.
- Wrapped the `mentorSearchInput` listener with a 300ms debounced call to `renderMentorFinder`.

## Testing

- Verified with `node --check` that the modified file has valid syntax.
- Manually confirmed typing in the search box no longer triggers a filter operation on every keystroke; filtering now runs only after a brief pause in typing.
- No change to filter behavior/output, only to timing of invocation.

Fixes #1970

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

