### PR TITLE
fix: verify and update mentor contact info for GNU Radio (#309)

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1966,7 +1966,7 @@
         {
             "type": "IRC",
             "label": "#gnuradio",
-            "url": "https://web.libera.chat/?channel=#gnuradio"
+            "url": "https://web.libera.chat/#gnuradio"
         }
     ],
     "mentors": [

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1956,14 +1956,37 @@
   },
   "GNU Radio": {
     "org": "GNU Radio",
-    "ideasUrl": "https://wiki.gnuradio.org/index.php/GSoC",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
-  },
+  "ideasUrl": "https://wiki.gnuradio.org/index.php/GSoCIdeas",
+  "channels": [
+    {
+      "type": "matrix",
+      "name": "#gnuradio:gnuradio.org",
+      "url": "https://chat.gnuradio.org/"
+    },
+    {
+      "type": "irc",
+      "name": "#gnuradio",
+      "url": "ircs://irc.libera.chat/gnuradio"
+    }
+  ],
+  "mentors": [
+    { "name": "Josh Morman", "github": "jmorman" },
+    { "name": "Marcus Müller", "github": "marcusmueller" },
+    { "name": "Cyrille Morin", "github": "cyrille-morin" },
+    { "name": "Luigi Cruz", "github": "luigi-cruz" },
+    { "name": "Håkon Vågsether", "github": "hakonvags" }
+  ],
+  "mailingLists": [
+    {
+      "name": "discuss-gnuradio",
+      "url": "https://lists.gnu.org/mailman/listinfo/discuss-gnuradio",
+      "email": "discuss-gnuradio@gnu.org"
+    }
+  ],
+  "tip": "Join #gnuradio on Matrix (chat.gnuradio.org) or IRC (Libera.Chat). Post on the mailing list discuss-gnuradio@gnu.org. Do not contact mentors off-list.",
+  "status": "ok",
+  "lastFetched": "2026-07-02T00:00:00.000Z"
+},
   "gprMax": {
     "org": "gprMax",
     "ideasUrl": "https://github.com/gprMax/GSoC/blob/main/project-ideas-2026.md",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1956,36 +1956,36 @@
   },
   "GNU Radio": {
     "org": "GNU Radio",
-  "ideasUrl": "https://wiki.gnuradio.org/index.php/GSoCIdeas",
-  "channels": [
-    {
-      "type": "matrix",
-      "name": "#gnuradio:gnuradio.org",
-      "url": "https://chat.gnuradio.org/"
-    },
-    {
-      "type": "irc",
-      "name": "#gnuradio",
-      "url": "ircs://irc.libera.chat/gnuradio"
-    }
-  ],
-  "mentors": [
-    { "name": "Josh Morman", "github": "jmorman" },
-    { "name": "Marcus Müller", "github": "marcusmueller" },
-    { "name": "Cyrille Morin", "github": "cyrille-morin" },
-    { "name": "Luigi Cruz", "github": "luigi-cruz" },
-    { "name": "Håkon Vågsether", "github": "hakonvags" }
-  ],
-  "mailingLists": [
-    {
-      "name": "discuss-gnuradio",
-      "url": "https://lists.gnu.org/mailman/listinfo/discuss-gnuradio",
-      "email": "discuss-gnuradio@gnu.org"
-    }
-  ],
-  "tip": "Join #gnuradio on Matrix (chat.gnuradio.org) or IRC (Libera.Chat). Post on the mailing list discuss-gnuradio@gnu.org. Do not contact mentors off-list.",
-  "status": "ok",
-  "lastFetched": "2026-07-02T00:00:00.000Z"
+    "ideasUrl": "https://wiki.gnuradio.org/index.php/GSoCIdeas",
+    "channels": [
+        {
+            "type": "matrix",
+            "name": "#gnuradio:gnuradio.org",
+            "url": "https://chat.gnuradio.org/"
+        },
+        {
+            "type": "irc",
+            "name": "#gnuradio",
+            "url": "ircs://irc.libera.chat/gnuradio"
+        }
+    ],
+    "mentors": [
+        { "name": "Josh Morman", "github": "jmorman" },
+        { "name": "Marcus Müller", "github": "marcusmueller" },
+        { "name": "Cyrille Morin", "github": "cyrille-morin" },
+        { "name": "Luigi Cruz", "github": "luigi-cruz" },
+        { "name": "Håkon Vågsether", "github": "hakonvags" }
+    ],
+    "mailingLists": [
+        {
+            "name": "discuss-gnuradio",
+            "url": "https://lists.gnu.org/mailman/listinfo/discuss-gnuradio",
+            "email": "discuss-gnuradio@gnu.org"
+        }
+    ],
+    "tip": "Join #gnuradio on Matrix (chat.gnuradio.org) or IRC (Libera.Chat). Post on the mailing list discuss-gnuradio@gnu.org. Do not contact mentors off-list.",
+    "status": "ok",
+    "lastFetched": "2026-07-02T00:00:00.000Z"
 },
   "gprMax": {
     "org": "gprMax",

--- a/data/mentors.json
+++ b/data/mentors.json
@@ -1959,26 +1959,27 @@
     "ideasUrl": "https://wiki.gnuradio.org/index.php/GSoCIdeas",
     "channels": [
         {
-            "type": "matrix",
-            "name": "#gnuradio:gnuradio.org",
+            "type": "Matrix",
+            "label": "#gnuradio:gnuradio.org",
             "url": "https://chat.gnuradio.org/"
         },
         {
-            "type": "irc",
-            "name": "#gnuradio",
-            "url": "ircs://irc.libera.chat/gnuradio"
+            "type": "IRC",
+            "label": "#gnuradio",
+            "url": "https://web.libera.chat/?channel=#gnuradio"
         }
     ],
     "mentors": [
-        { "name": "Josh Morman", "github": "jmorman" },
-        { "name": "Marcus Müller", "github": "marcusmueller" },
-        { "name": "Cyrille Morin", "github": "cyrille-morin" },
-        { "name": "Luigi Cruz", "github": "luigi-cruz" },
-        { "name": "Håkon Vågsether", "github": "hakonvags" }
+        { "name": "Josh Morman", "github": "jmorman", "githubUrl": "https://github.com/jmorman" },
+        { "name": "Marcus Müller", "github": "marcusmueller", "githubUrl": "https://github.com/marcusmueller" },
+        { "name": "Cyrille Morin", "github": "cyrille-morin", "githubUrl": "https://github.com/cyrille-morin" },
+        { "name": "Luigi Cruz", "github": "luigi-cruz", "githubUrl": "https://github.com/luigi-cruz" },
+        { "name": "Håkon Vågsether", "github": "hakonvags", "githubUrl": "https://github.com/hakonvags" }
     ],
     "mailingLists": [
         {
-            "name": "discuss-gnuradio",
+            "type": "Mailing list",
+            "label": "discuss-gnuradio",
             "url": "https://lists.gnu.org/mailman/listinfo/discuss-gnuradio",
             "email": "discuss-gnuradio@gnu.org"
         }


### PR DESCRIPTION
## Description
Verified and updated mentor contact info for GNU Radio. All channels sourced directly from wiki.gnuradio.org and gnuradio.org/community.

## Related Issue
Closes #309

## Type of Change
- [x] Bug fix / Data fix

## Checklist
- [x] I have signed my commits using git commit -s
- [x] My changes are focused and relevant
- [x] I have linked a valid issue

PROGRAM: gssoc

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

