### PR TITLE
feat: add keyboard shortcuts for search focus and section navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1356,6 +1356,7 @@ kbd:hover{
           <div class="relative z-10 bg-white dark:bg-[#18181b] rounded-[calc(1rem-1.5px)] w-full search-border-inner flex items-center gap-2 transition-all duration-300">
             <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">search</span>
             <input id="hero-search" type="text" placeholder="Search organization names..." aria-label="Search GSoC 2026 organizations" class="flex-1 bg-transparent border-0 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-0 focus:outline-none transition-all text-zinc-900 dark:text-zinc-100" />
+            <span class="hidden sm:inline-flex items-center gap-0.5 mr-2 px-1.5 py-0.5 rounded-md border border-zinc-300 dark:border-zinc-600 text-[10px] font-mono font-semibold text-zinc-400 dark:text-zinc-500 select-none" aria-hidden="true">⌘K</span>
             <button id="hero-search-submit" type="button" class="mr-2 inline-flex items-center justify-center rounded-xl bg-primary px-4 py-2 text-xs sm:text-sm font-bold text-white transition-colors hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-primary/30">
               Search
             </button>
@@ -5199,7 +5200,7 @@ if(org.ideas){
   }
 </script>
 
-<div class="modal-bg" id="helpModal">
+<div class="modal-bg" id="helpModal" role="dialog" aria-modal="true" aria-labelledby="helpModalTitle">
   <div class="modal">
     
     <button class="close-btn" onclick="closeHelpModal()"  aria-label="Close keyboard shortcuts modal">
@@ -5209,7 +5210,7 @@ if(org.ideas){
     
 
     <div class="modal-header">
-      <h2>Keyboard Shortcuts</h2>
+      <h2 id="helpModalTitle">Keyboard Shortcuts</h2>
       <p>Quick shortcuts for navigation</p>
     </div>
 
@@ -5245,8 +5246,18 @@ if(org.ideas){
 </tr>
 
 <tr class="shortcut-row">
-  <td class="py-2"><kbd>/</kbd></td>
+  <td class="py-2"><kbd>/</kbd> or <kbd>⌘</kbd><kbd>K</kbd></td>
   <td class="py-2">Focus search bar</td>
+</tr>
+
+<tr class="shortcut-row">
+  <td class="py-2"><kbd>⌘</kbd><kbd>1</kbd></td>
+  <td class="py-2">Jump to Timeline section</td>
+</tr>
+
+<tr class="shortcut-row">
+  <td class="py-2"><kbd>⌘</kbd><kbd>2</kbd></td>
+  <td class="py-2">Jump to Organizations section</td>
 </tr>
 
 
@@ -5327,17 +5338,35 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
 document.addEventListener('keydown', (e) => {
+  const active = document.activeElement;
+  const isTyping = active && (
+    ['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName) ||
+    active.id === 'searchInput'
+  );
+
+  // Focus search bar — works alongside Ctrl/Cmd but not while already typing
+  if (!isTyping && (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k'))) {
+    e.preventDefault();
+    document.getElementById('hero-search')?.focus();
+    return;
+  }
+  // Jump to Timeline section
+  if (!isTyping && (e.metaKey || e.ctrlKey) && e.key === '1') {
+    e.preventDefault();
+    document.getElementById('timeline')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return;
+  }
+  // Jump to Organizations section
+  if (!isTyping && (e.metaKey || e.ctrlKey) && e.key === '2') {
+    e.preventDefault();
+    document.getElementById('orgs')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return;
+  }
+
     if (e.ctrlKey || e.metaKey || e.altKey) {
     return;
 }
-  const active = document.activeElement;
-if (
-    active &&
-    (
-        ['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName) ||
-        active.id === 'searchInput'
-    )
-) {
+    if (isTyping) {
         return;
     }
 const helpModalOpen =

--- a/index.html
+++ b/index.html
@@ -5251,12 +5251,12 @@ if(org.ideas){
 </tr>
 
 <tr class="shortcut-row">
-  <td class="py-2"><kbd>⌘</kbd><kbd>1</kbd></td>
+  <td class="py-2"><kbd>Alt</kbd><kbd>1</kbd></td>
   <td class="py-2">Jump to Timeline section</td>
 </tr>
 
 <tr class="shortcut-row">
-  <td class="py-2"><kbd>⌘</kbd><kbd>2</kbd></td>
+  <td class="py-2"><kbd>Alt</kbd><kbd>2</kbd></td>
   <td class="py-2">Jump to Organizations section</td>
 </tr>
 

--- a/index.html
+++ b/index.html
@@ -1356,7 +1356,7 @@ kbd:hover{
           <div class="relative z-10 bg-white dark:bg-[#18181b] rounded-[calc(1rem-1.5px)] w-full search-border-inner flex items-center gap-2 transition-all duration-300">
             <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400">search</span>
             <input id="hero-search" type="text" placeholder="Search organization names..." aria-label="Search GSoC 2026 organizations" class="flex-1 bg-transparent border-0 rounded-2xl py-3 sm:py-4 pl-12 pr-4 text-sm font-medium focus:ring-0 focus:outline-none transition-all text-zinc-900 dark:text-zinc-100" />
-            <span class="hidden sm:inline-flex items-center gap-0.5 mr-2 px-1.5 py-0.5 rounded-md border border-zinc-300 dark:border-zinc-600 text-[10px] font-mono font-semibold text-zinc-400 dark:text-zinc-500 select-none" aria-hidden="true">⌘K</span>
+            <span class="hidden sm:inline-flex items-center gap-0.5 mr-2 px-1.5 py-0.5 rounded-md border border-zinc-300 dark:border-zinc-600 text-[10px] font-mono font-semibold text-zinc-400 dark:text-zinc-500 select-none" aria-hidden="true">⌘/Ctrl K</span>
             <button id="hero-search-submit" type="button" class="mr-2 inline-flex items-center justify-center rounded-xl bg-primary px-4 py-2 text-xs sm:text-sm font-bold text-white transition-colors hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-primary/30">
               Search
             </button>
@@ -5320,16 +5320,38 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const helpModal = document.getElementById('helpModal');
   const helpBtn = document.getElementById('helpBtn');
+  let helpModalTriggerEl = null;
+
+  function trapHelpModalFocus(e) {
+    if (e.key !== 'Tab' || !helpModal) return;
+    const focusables = helpModal.querySelectorAll('button, [href], input, select, textarea, [tabindex="0"]');
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      last.focus();
+      e.preventDefault();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      first.focus();
+      e.preventDefault();
+    }
+  }
 
   function openHelpModal() {
     if (helpModal) {
+      helpModalTriggerEl = document.activeElement;
       helpModal.classList.add('open');
+      helpModal.querySelector('.close-btn')?.focus();
+      document.addEventListener('keydown', trapHelpModalFocus);
     }
   }
 
   function closeHelpModal() {
     if (helpModal) {
       helpModal.classList.remove('open');
+      document.removeEventListener('keydown', trapHelpModalFocus);
+      helpModalTriggerEl?.focus();
+      helpModalTriggerEl = null;
     }
   }
 
@@ -5344,20 +5366,28 @@ document.addEventListener('keydown', (e) => {
     active.id === 'searchInput'
   );
 
-  // Focus search bar — works alongside Ctrl/Cmd but not while already typing
-  if (!isTyping && (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k'))) {
+  const helpModalOpen =
+    document.getElementById('helpModal')?.classList.contains('open');
+  const orgModalOpen =
+    document.getElementById('orgModal')?.classList.contains('open');
+  const proposalModalOpen =
+    document.getElementById('proposalModal')?.classList.contains('open');
+  const anyModalOpen = helpModalOpen || orgModalOpen || proposalModalOpen;
+
+  // Focus search bar — works alongside Ctrl/Cmd but not while already typing or a modal is open
+  if (!anyModalOpen && !isTyping && (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k'))) {
     e.preventDefault();
     document.getElementById('hero-search')?.focus();
     return;
   }
   // Jump to Timeline section
-  if (!isTyping && (e.metaKey || e.ctrlKey) && e.key === '1') {
+  if (!anyModalOpen && !isTyping && (e.metaKey || e.ctrlKey) && e.key === '1') {
     e.preventDefault();
     document.getElementById('timeline')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;
   }
   // Jump to Organizations section
-  if (!isTyping && (e.metaKey || e.ctrlKey) && e.key === '2') {
+  if (!anyModalOpen && !isTyping && (e.metaKey || e.ctrlKey) && e.key === '2') {
     e.preventDefault();
     document.getElementById('orgs')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;
@@ -5369,16 +5399,7 @@ document.addEventListener('keydown', (e) => {
     if (isTyping) {
         return;
     }
-const helpModalOpen =
-  document.getElementById('helpModal')?.classList.contains('open');
-
-const orgModalOpen =
-  document.getElementById('orgModal')?.classList.contains('open');
-
-const proposalModalOpen =
-  document.getElementById('proposalModal')?.classList.contains('open');
-
-if (helpModalOpen || orgModalOpen || proposalModalOpen) {
+if (anyModalOpen) {
   return;
 }
 

--- a/index.html
+++ b/index.html
@@ -5373,7 +5373,6 @@ document.addEventListener('keydown', (e) => {
   const proposalModalOpen =
     document.getElementById('proposalModal')?.classList.contains('open');
   const anyModalOpen = helpModalOpen || orgModalOpen || proposalModalOpen;
-
   // Focus search bar — works alongside Ctrl/Cmd but not while already typing or a modal is open
   if (!anyModalOpen && !isTyping && (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k'))) {
     e.preventDefault();
@@ -5381,13 +5380,13 @@ document.addEventListener('keydown', (e) => {
     return;
   }
   // Jump to Timeline section
-  if (!anyModalOpen && !isTyping && (e.metaKey || e.ctrlKey) && e.key === '1') {
+  if (!anyModalOpen && !isTyping && e.altKey && e.key === '1') {
     e.preventDefault();
     document.getElementById('timeline')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;
   }
   // Jump to Organizations section
-  if (!anyModalOpen && !isTyping && (e.metaKey || e.ctrlKey) && e.key === '2') {
+  if (!anyModalOpen && !isTyping && e.altKey && e.key === '2') {
     e.preventDefault();
     document.getElementById('orgs')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;
@@ -5399,7 +5398,7 @@ document.addEventListener('keydown', (e) => {
     if (isTyping) {
         return;
     }
-if (anyModalOpen) {
+if (anyModalOpen && e.key !== 'Escape') {
   return;
 }
 

--- a/index.html
+++ b/index.html
@@ -5362,8 +5362,7 @@ document.addEventListener('DOMContentLoaded', () => {
 document.addEventListener('keydown', (e) => {
   const active = document.activeElement;
   const isTyping = active && (
-    ['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName) ||
-    active.id === 'searchInput'
+    ['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName)
   );
 
   const helpModalOpen =

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -731,12 +731,12 @@ function handleGlobalKeydown(e) {
     document.getElementById('hero-search')?.focus();
     return;
   }
-  if (!anyModalOpen && (e.metaKey || e.ctrlKey) && e.key === '1') {
+  if (!anyModalOpen && e.altKey && e.key === '1') {
     e.preventDefault();
     document.getElementById('timeline')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;
   }
-  if (!anyModalOpen && (e.metaKey || e.ctrlKey) && e.key === '2') {
+  if (!anyModalOpen && e.altKey && e.key === '2') {
     e.preventDefault();
     document.getElementById('orgs')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -724,9 +724,19 @@ function handleGlobalKeydown(e) {
     openModalElement('helpModal');
     return;
   }
-  if (e.key === '/') {
+  if (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k')) {
     e.preventDefault();
-    document.getElementById('searchInput')?.focus();
+    document.getElementById('hero-search')?.focus();
+    return;
+  }
+  if ((e.metaKey || e.ctrlKey) && e.key === '1') {
+    e.preventDefault();
+    document.getElementById('timeline')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return;
+  }
+  if ((e.metaKey || e.ctrlKey) && e.key === '2') {
+    e.preventDefault();
+    document.getElementById('orgs')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;
   }
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -664,7 +664,7 @@ function updateCardFocus() {
 
 // Global keydown helper functions to manage Cognitive Complexity
 function handleEscapeKey(e) {
-  const activeModal = document.querySelector('.modal-bg.open, #mobileMenu:not(.hidden), .modal-bg.compare-bg.open');
+  const activeModal = document.querySelector('.modal-bg.open, #mobileMenu:not(.hidden), .modal-bg.compare-bg.open, #proposalModal.open, #proposalModal[open]');
   if (activeModal) {
     e.preventDefault();
     closeModalElement(activeModal.id);
@@ -719,7 +719,10 @@ function handleGlobalKeydown(e) {
   if (['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement?.tagName)) return;
 
   const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open, #proposalModal.open, #proposalModal[open]');
+  const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open, #proposalModal.open, #proposalModal[open]');
+if (anyModalOpen) return;
 
+const n = filteredOrgs.length;
   const n = filteredOrgs.length;
   if (!anyModalOpen && e.key === '?') {
     e.preventDefault();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -721,7 +721,7 @@ function handleGlobalKeydown(e) {
   const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open');
 
   const n = filteredOrgs.length;
-  if (e.key === '?') {
+  if (!anyModalOpen && e.key === '?') {
     e.preventDefault();
     openModalElement('helpModal');
     return;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -718,7 +718,7 @@ function handleGlobalKeydown(e) {
 
   if (['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement?.tagName)) return;
 
-  const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open');
+  const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open, #proposalModal.open, #proposalModal[open]');
 
   const n = filteredOrgs.length;
   if (!anyModalOpen && e.key === '?') {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -718,23 +718,25 @@ function handleGlobalKeydown(e) {
 
   if (['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement?.tagName)) return;
 
+  const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open');
+
   const n = filteredOrgs.length;
   if (e.key === '?') {
     e.preventDefault();
     openModalElement('helpModal');
     return;
   }
-  if (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k')) {
+  if (!anyModalOpen && (e.key === '/' || ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k'))) {
     e.preventDefault();
     document.getElementById('hero-search')?.focus();
     return;
   }
-  if ((e.metaKey || e.ctrlKey) && e.key === '1') {
+  if (!anyModalOpen && (e.metaKey || e.ctrlKey) && e.key === '1') {
     e.preventDefault();
     document.getElementById('timeline')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;
   }
-  if ((e.metaKey || e.ctrlKey) && e.key === '2') {
+  if (!anyModalOpen && (e.metaKey || e.ctrlKey) && e.key === '2') {
     e.preventDefault();
     document.getElementById('orgs')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     return;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -719,10 +719,8 @@ function handleGlobalKeydown(e) {
   if (['INPUT', 'SELECT', 'TEXTAREA'].includes(document.activeElement?.tagName)) return;
 
   const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open, #proposalModal.open, #proposalModal[open]');
-  const anyModalOpen = !!document.querySelector('.modal-bg.open, .modal-bg.compare-bg.open, #proposalModal.open, #proposalModal[open]');
 if (anyModalOpen) return;
 
-const n = filteredOrgs.length;
   const n = filteredOrgs.length;
   if (!anyModalOpen && e.key === '?') {
     e.preventDefault();


### PR DESCRIPTION
## 📝 Description
Adds working keyboard shortcuts for search focus and section navigation. `/` previously pointed at a hidden input and did nothing in production — this fixes that and adds `⌘K`/`Ctrl+K` as an alternate way to focus the search bar, plus Alt+1 and Alt+2 to jump to the Timeline and Organizations sections (chosen over Ctrl/Cmd+1/2 since those are reserved by browsers for tab-switching). Also adds `role="dialog"` and `aria-modal` to the help modal for accessibility, documents the new shortcuts in the help table, and adds a visible `⌘K` hint chip on the search bar.

## 🔗 Related Issue
Closes #1989

## 🚀 Program Classification
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [x] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `index.html` in a browser
2. Press `/` or `⌘K` (`Ctrl+K` on Windows/Linux) — the search bar should be focused
3. Press Alt+1 — the page should smoothly scroll to the Timeline section
4. Press Alt+2 — the page should smoothly scroll to the Organizations section
5. Press `?` — the help modal should open, showing the updated shortcuts list
6. Inspect the help modal element — it should have `role="dialog"` and `aria-modal="true"`
7. Ran `npm run lint:js`, `npm run lint:html`, and `npm test` locally — all pass (25/25 tests)

## 📸 Screenshots (if applicable)
_Not applicable — behavioral/keyboard change, no visual redesign._

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

