### PR TITLE
feat: add dedicated contributing webpage

### DIFF
--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -37,7 +37,7 @@
           <span class="material-symbols-outlined text-base">menu_book</span> Resources
         </a>
         <a class="footer-link text-sm text-zinc-600 hover:text-primary dark:text-zinc-300 dark:hover:text-primary transition-all flex items-center gap-1.5"
-          href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-/blob/main/CONTRIBUTING.md">
+          href="contributing.html">
           <span class="material-symbols-outlined text-base">volunteer_activism</span> Contributing
         </a>
         <a class="footer-link text-sm text-zinc-600 hover:text-primary dark:text-zinc-300 dark:hover:text-primary transition-all flex items-center gap-1.5"

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
   "routes": [
     { "src": "/app/(.*)", "dest": "/index.html" },
     { "src": "/app", "dest": "/index.html" },
+    { "src": "/contributing", "dest": "/contributing.html" },
     {
       "src": "/api/(.*)",
       "headers": {


### PR DESCRIPTION
## Summary
- add a dedicated contributing page for the site
- route the footer contribution link to the new page
- add a regression test for the new page

## Testing
- npm test

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/1996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

