### PR TITLE
docs: update mentor information for TARDIS RT Collaboration, The Honeynet Project, and Uramaki LAB

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -4737,14 +4737,51 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "TARDIS RT Collaboration": {
-    "org": "TARDIS RT Collaboration",
-    "ideasUrl": "https://github.com/tardis-sn/tardis/wiki/GSOC",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+  "org": "TARDIS RT Collaboration",
+  "ideasUrl": "https://tardis-sn.github.io/summer_of_code/ideas/",
+  "channels": [
+    {
+      "type": "Gitter",
+      "url": "https://app.gitter.im/#/room/#tardis-sn_tardis:gitter.im",
+      "label": "TARDIS Gitter"
+    }
+  ],
+  "mentors": [
+    {
+      "name": "Andrew Fullard",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Atharva Arya",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Josh Shields",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Connor McClellan",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Jaladh Singhal",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Jared Goldberg",
+      "github": "",
+      "githubUrl": ""
+    }
+  ],
+  "mailingLists": [],
+  "tip": "",
+  "status": "ok",
+  "lastFetched": "2026-06-30T16:45:00.000Z"
   },
   "The FreeBSD Project": {
     "org": "The FreeBSD Project",
@@ -4760,17 +4797,38 @@
     "org": "The Honeynet Project",
     "ideasUrl": "https://www.honeynet.org/gsoc/gsoc-2026/",
     "channels": [
-      {
-        "type": "Discord",
-        "url": "https://discord.gg/68B8Ru5fSU",
-        "label": "The Honeynet Project Discord"
-      }
-    ],
-    "mentors": [],
-    "mailingLists": [],
+  {
+    "type": "Discord",
+    "url": "https://discord.gg/68B8Ru5fSU",
+    "label": "The Honeynet Project Discord"
+  }
+  ],
+  "mentors": [
+    {
+      "name": "Manolis Vasilomanolakis",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Krzysztof Zając",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Tim Leonhard",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Matteo Lodi",
+      "github": "",
+      "githubUrl": ""
+    }
+  ],
+  "mailingLists": [],
     "tip": "Introduce yourself in the public channel before asking project-specific questions.",
     "status": "ok",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "lastFetched": "2026-06-30T16:45:00.000Z"
   },
   "The JPF team": {
     "org": "The JPF team",
@@ -5523,14 +5581,57 @@
     "lastFetched": "2026-05-09T16:09:12.548Z"
   },
   "Uramaki LAB": {
-    "org": "Uramaki LAB",
-    "ideasUrl": "https://summerofcode.withgoogle.com/programs/2026/organizations/uramaki-lab",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "no-contact-found",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+  "org": "Uramaki LAB",
+  "ideasUrl": "https://ruxailab.github.io/gsoc/",
+  "channels": [
+    {
+        "type": "GitHub",
+        "url": "https://github.com/ruxailab/RUXAILAB/issues",
+        "label": "GitHub Issues"
+    },
+    {
+        "type": "Discord",
+        "url": "https://discord.com/invite/6P4C6xuqtC",
+        "label": "RUXAILAB Discord"
+    }
+  ],
+
+  "mentors": [
+    {
+      "name": "Marc Gonzalez Capdevila",
+      "github": "marcgc21",
+      "githubUrl": "https://github.com/marcgc21"
+    },
+    {
+      "name": "Karine Pistili Rodrigues",
+      "github": "KarinePistili",
+      "githubUrl": "https://github.com/KarinePistili"
+    },
+    {
+      "name": "Leticia Carvalho Ramos",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Basma Hatem",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Sitam Meur",
+      "github": "",
+      "githubUrl": ""
+    },
+    {
+      "name": "Eric Monné Mesalles",
+      "github": "xemyst",
+      "githubUrl": "https://github.com/xemyst"
+    }
+  ],
+  "mailingLists": [],
+  "tip": "",
+  "status": "ok",
+  "lastFetched": "2026-06-30T16:45:00.000Z"
   },
   "VideoLAN": {
     "org": "VideoLAN",


### PR DESCRIPTION
## 📝 Description
This PR updates mentor information for multiple organizations by manually verifying their official GSoC 2026 ideas pages and communication channels. It includes updates for TARDIS RT Collaboration, The Honeynet Project, and Uramaki LAB by adding mentor details, communication channels, updating ideas page URLs where needed, and setting the organization status after verification.

## 🔗 Related Issue

Closes #412
Closes #414
Closes #430

---

## 🚀 Program Classification

- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

---

## 🔄 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [x] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

---

## 🧪 How to Test

1. Open `data/mentors.json`.
2. Verify the updated entries for:
   - TARDIS RT Collaboration
   - The Honeynet Project
   - Uramaki LAB
3. Confirm that the ideas page URLs, mentor information, communication channels, mailing lists (where applicable), and status fields have been updated correctly.
4. Ensure the JSON file remains valid.

---

## 📸 Screenshots (if applicable)

Not applicable.

---

## ✅ Checklist

- [x] My code follows the project's existing style
- [ ] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

