### PR TITLE
feat:added scrollable org and mentor directories

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@ kbd:hover{
   <!-- Hidden search input for JavaScript compatibility -->
   <input type="hidden" id="searchInput" />
   
-  <div class="org-grid grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" id="orgGrid">
+  <div class="org-grid grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 scrollable-directory org-directory" id="orgGrid">
     <!-- Organizations will be rendered here dynamically -->
     <div class="col-span-full py-20 text-center animate-pulse">
       <p class="text-zinc-400 font-headline italic">Loading organization directory...</p>
@@ -1877,7 +1877,7 @@ kbd:hover{
       </div>
     </div>
 
-    <div id="mentorGrid" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 scrollable-directory mentor-directory" id="mentorGrid">
       <div class="col-span-full bg-white rounded-2xl border border-zinc-100 p-8 text-center">
         <p class="text-sm text-zinc-500">Loading mentor contact data...</p>
       </div>
@@ -1891,7 +1891,7 @@ kbd:hover{
   </div>
   <div id="mentorPagination" class="mt-10 flex flex-nowrap items-center justify-center gap-1 overflow-x-auto no-scrollbar" aria-label="Mentor pagination"></div>
 </section>
- 
+
 <!-- ═══════════════════ CONTRIBUTOR GUIDE ═══════════════════ -->
 <section id="guide" class="py-20 px-6 max-w-7xl mx-auto">
   <div class="mb-12">
@@ -2972,6 +2972,18 @@ kbd:hover{
       entry: getMentorEntry(org.name)
     }));
   }
+  function scrollDirectoryToTop(gridId) {
+    const grid = document.getElementById(gridId);
+    if (grid) {
+      grid.scrollTop = 0;
+      const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      const header = document.querySelector('nav') || document.querySelector('header');
+      const headerHeight = header ? header.getBoundingClientRect().height : 80;
+      const SCROLL_OFFSET = 16;
+      const gridTop = grid.getBoundingClientRect().top + window.scrollY - headerHeight - SCROLL_OFFSET;
+      window.scrollTo({ top: gridTop, behavior: prefersReduced ? 'auto' : 'smooth' });
+    }
+  }
 
   function renderMentorFinder(reset = true) {
     const grid = document.getElementById('mentorGrid');
@@ -3133,9 +3145,8 @@ kbd:hover{
     renderPaginationControls('mentorPagination', filteredRecords.length, mentorCurrentPage, (page) => {
       mentorCurrentPage = page;
       renderMentorFinder(false);
-      document.getElementById('mentors')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      scrollDirectoryToTop('mentorGrid');
     });
-
     attachOrgCardListeners(grid);
   }
 
@@ -3494,7 +3505,7 @@ function renderPaginationControls(containerId, totalItems, currentPage, onPageCh
     renderPaginationControls('orgPagination', filteredOrgs.length, orgCurrentPage, (page) => {
       orgCurrentPage = page;
       renderOrgs(false);
-      document.getElementById('orgs')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      scrollDirectoryToTop('orgGrid');
     });
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -202,6 +202,57 @@ body{background:var(--bg);color:var(--ink);font-family:'Plus Jakarta Sans',sans-
 /* ── GRID ── */
 .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(310px,1fr));gap:12px;margin-bottom:60px}
 
+/* ── SCROLLABLE DIRECTORIES ── */
+.scrollable-directory {
+  overflow-y: auto;
+  padding-right: 4px;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.scrollable-directory.org-directory {
+  max-height: 500px;
+}
+
+.scrollable-directory.mentor-directory {
+  max-height: 800px;
+}
+
+.scrollable-directory::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scrollable-directory::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollable-directory::-webkit-scrollbar-thumb {
+  background-color: var(--border);
+  border-radius: 999px;
+}
+
+.scrollable-directory::-webkit-scrollbar-thumb:hover {
+  background-color: var(--orange);
+}
+
+.scrollable-directory:hover,
+.scrollable-directory:focus,
+.scrollable-directory:focus-visible {
+  scrollbar-color: var(--orange) transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scrollable-directory {
+    scroll-behavior: auto;
+  }
+}
+
+.scrollable-directory:focus-visible {
+  outline: 2px solid var(--orange);
+  outline-offset: 2px;
+}
+
 .org-card{display:flex;flex-direction:column;height:100%;background:var(--card-bg);border:1.5px solid var(--border);border-radius:14px;padding:18px;cursor:pointer;position:relative;overflow:hidden;animation:fadeUp .25s ease forwards;transition:border-color .18s,box-shadow .18s,transform .15s,background .3s}
 .org-card::after{content:'';position:absolute;top:0;left:0;right:0;height:2.5px;background:linear-gradient(90deg,var(--orange),#FBBC04);opacity:0;transition:opacity .2s}
 .org-card:hover,.org-card.focused{border-color:var(--orange-border);box-shadow:0 4px 20px rgba(244,107,14,.1);transform:translateY(-2px)}


### PR DESCRIPTION
## 📝 Description
Implemented scrollable architecture for the Organizations and Mentors directory sections to improve page performance and user experience.

## Changes:

Added max-height: 500px with overflow-y: auto to #orgGrid and max-height: 800px to #mentorGrid in src/styles.css
Added custom scrollbar styling for both grids matching the existing design system (thin 6px bar, orange on hover, transparent track)
Added scrollTop = 0 reset on both grids when changing pages so the internal scroll position resets on pagination
Added smooth page scroll to the top of each grid (with an 80px offset) when changing pages so the user is automatically brought back to the top of the grid without manual scrolling

## 🔗 Related Issue
Closes #686 

## 🚀 Program Classification
- [x] GSSoC26


## 🔄 Type of Change
<!-- Check all that apply -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## Tested:

Verified scrollable behavior works on both Organizations and Mentors sections
Confirmed pagination controls remain visible below the scrollable area
Confirmed internal scroll resets to top on page change
Confirmed page scrolls up to top of grid on page change with correct offset
Tested on both desktop and mobile viewports


## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

