### PR TITLE
fix: prevented TypeError by validating null input

### DIFF
--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -190,6 +190,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let visibleCount = 6;
 
   document.addEventListener('compareListChanged', () => {
+    if (!resultsContainer) return;
+
     const currentCompareList = globalThis.compareList || [];
     resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
       const card = btn.closest('[data-org-name]');

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -189,17 +189,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const errorMsg = document.getElementById('aiErrorMsg');
   let visibleCount = 6;
 
-  document.addEventListener('compareListChanged', () => {
-    if (!resultsContainer) return;
 
-    const currentCompareList = globalThis.compareList || [];
-    resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
-      const card = btn.closest('[data-org-name]');
-      const name = btn.dataset.compareOrg;
-      const isNowComparing = currentCompareList.includes(name);
-      updateCompareVisualState(btn, card, isNowComparing);
+  if (resultsContainer) {
+    document.addEventListener('compareListChanged', () => {
+      const currentCompareList = globalThis.compareList || [];
+      resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
+        const card = btn.closest('[data-org-name]');
+        const name = btn.dataset.compareOrg;
+        const isNowComparing = currentCompareList.includes(name);
+        updateCompareVisualState(btn, card, isNowComparing);
+      });
     });
-  });
+  }
 
   // Handle file upload
   if (fileUpload) {


### PR DESCRIPTION
## 📝 Description
Wraped listener registration in `if (resultsContainer) {  }` so it's only attached when the element is actually present.

## 🔗 Related Issue
Closes #1998 

## 🚀 Program Classification
<!-- Choose the program this contribution is for -->
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [x] 🧹 Refactor / cleanup

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

