### PR TITLE
Fix: View button not opening org modal

### DIFF
--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -101,9 +101,9 @@ function handleCompareAction(e, btn) {
 }
 
 function handleCardActivation(card) {
-  const idx = parseInt(card.dataset.orgIndex, 10);
-  if (typeof openModal === 'function' && !isNaN(idx) && idx >= 0) {
-    openModal(idx);
+  const name = card.dataset.orgName;
+  if (typeof openModal === 'function' && name) {
+    openModal(name);
   }
 }
 
@@ -190,8 +190,6 @@ document.addEventListener('DOMContentLoaded', () => {
   let visibleCount = 6;
 
   document.addEventListener('compareListChanged', () => {
-    if (!resultsContainer) return;
-
     const currentCompareList = globalThis.compareList || [];
     resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
       const card = btn.closest('[data-org-name]');

--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -190,6 +190,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let visibleCount = 6;
 
   document.addEventListener('compareListChanged', () => {
+    if (!resultsContainer) return;
+
     const currentCompareList = globalThis.compareList || [];
     resultsContainer.querySelectorAll('[data-compare-org]').forEach(btn => {
       const card = btn.closest('[data-org-name]');


### PR DESCRIPTION
## 📝 Description
**The Bug:**
Clicking 'View' (or anywhere on a recommendation card) silently did nothing no console error, no modal.
`handleCardActivation()` parsed `card.dataset.orgIndex` & called `openModal(idx)`but `openModal(name)` looks orgs up by name:
```js
const org = ORGS.find(o => o.name === name);
if (!org) return; // silently fails when index never matches a name
```

**Solution:**
Used `card.dataset.orgName` (already present on the card element) instead of the index matching `openModal`'s actual signature.

```js
const name = card.dataset.orgName;
  if (typeof openModal === 'function' && name) {
    openModal(name);
  }
```

## 🔗 Related Issue
Closes #2006

## 🚀 Program Classification
<!-- Choose the program this contribution is for -->
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
<!-- Check all that apply -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [x] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 🧪 How to Test
1. Open `index.html` in a browser
2. Navigate to [AI Recommender](https://findmygsoc.vercel.app/app#ai-recommender)
3. Enter a valid GitHub username & skills.
4. Click Get Recommendations.
5. Once recommendation cards are displayed click the VIEW button on any organization card
6. Now they are displayed the info about org.

## 📸 Screenshots
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/74f10fc5-b35b-47b9-9314-23fb732892ff" />

**All test cases are passing too:**
<img width="1899" height="166" alt="image" src="https://github.com/user-attachments/assets/9577a95c-02fb-442a-9766-a38d6c843018" />

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

