### PR TITLE
Fix: validate resume file size before reading into memory

### DIFF
--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -204,6 +204,14 @@ document.addEventListener('DOMContentLoaded', () => {
     fileUpload.addEventListener('change', (e) => {
       const file = e.target.files[0];
       if (!file) return;
+
+      const MAX_RESUME_SIZE = 5 * 1024 * 1024; //5MB
+      if (file.size > MAX_RESUME_SIZE) {
+        showError(`File too large (${(file.size / 1024 / 1024).toFixed(1)}MB). Please upload a file under 5MB.`);
+        fileUpload.value = '';
+        return;
+      }
+
       file.text().then(text => {
         resumeText.value = text;
       }).catch(err => {


### PR DESCRIPTION
## 📝 Description

**The Problem:**
The resume upload handler (`Upload .txt` under AI Recommender) called `file.text()` unconditionally on the selected file loading its entire contents into a single in memory string with no size check.

**The Fix:**
- Added a `MAX_RESUME_SIZE` cap (5MB) checked before calling `file.text()`
- Shows a user facing error via existing `showError()` if the file exceeds the limit
- Resets `fileUpload.value` on rejection so re selecting the same file re-fires `change`
- Went through the [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html) File Upload Cheat Sheet checklist item by item. Most items assume a server receives, stores, parses or re serving the file but none of those applies in this project as the file is read client side via `file.text()` into a textarea value & never leaves the browser or gets parsed as a structured format.
The one item that genuinely applies client side is the **file size limit**.

**Security perspective:**
 principles that needs be followed to reach a secure file upload implementation according to [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html) : 
<img width="758" height="583" alt="image" src="https://github.com/user-attachments/assets/9a62c6b1-50b8-4879-bc67-e2210f84b2f1" />

How these points are satisfied in the codebase:
1. Because the file is only ever read as text via `file.text()` an allowed extensions check wouldn't add real security here since nothing branches on type.
2. The structure of the file is never parsed, only decode bytes to text in the `extractSkills()`.
3. Nothing reads `file.type` or branches logic on it anywhere in this code.
<img width="1897" height="167" alt="Screenshot_2026-07-11-17-11-18 (Edit)" src="https://github.com/user-attachments/assets/3edcb5b8-97c2-49d7-ab3f-8743e8126c98" />

4,5. The filename is never stored. It's discarded after `e.target.files[0]` is read.
6. Applied at client side (5MB)
7. This is a public & unauthenticated site so can't be enforced here.
8. File is  never stored anywhere in the project.
9. There's no server receiving the file to scan, file is just decoded bytes to text in the `extractSkills()`.
10. The file is never stored, no retrieval endpoint & no public access to the file i.e. nothing is ever served back to the uploading user or anyone else.
11. CDR strips active content from structured formats during reconstruction. But the file is never parsed, `.txt` is read as raw text so there's no structured content to disarm.
12. Not an upload specific fix.
13. CSRF matters when a request is submitted to a server but here the file never leaves the browser, just extracted in the `extractSkills()`.

### Testing
- Uploaded a 4.3MB .txt file & rejected with error message ( at `MAX_RESUME_SIZE` = 1MB).
- Uploaded a normal sized resume `.txt` works as before.
- Re selecting the same oversized file after rejection re triggers validation correctly.

## 🔗 Related Issue
Closes #2005

## 🚀 Program Classification
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [x] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 📸 Screenshots
<img width="1906" height="948" alt="image" src="https://github.com/user-attachments/assets/a0e71fc8-d415-481e-9e1f-dd756ef20fc2" />


## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

