### PR TITLE
fix(ci): guard PR stage manager comment writes against read-only fork token

### DIFF
--- a/.github/workflows/pr-stage-manage.yml
+++ b/.github/workflows/pr-stage-manage.yml
@@ -527,27 +527,45 @@ jobs:
                 return;
               }
 
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body
-              });
+              try {
 
-              core.info(
-                'Updated pipeline comment'
-              );
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body
+                });
+
+                core.info(
+                  'Updated pipeline comment'
+                );
+
+              } catch (e) {
+
+                core.warning(
+                  `Failed updating pipeline comment: ${e.message}`
+                );
+              }
 
             } else {
 
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: Number(prNumber),
-                body
-              });
+              try {
 
-              core.info(
-                'Created pipeline comment'
-              );
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: Number(prNumber),
+                  body
+                });
+
+                core.info(
+                  'Created pipeline comment'
+                );
+
+              } catch (e) {
+
+                core.warning(
+                  `Failed creating pipeline comment: ${e.message}`
+                );
+              }
             }


### PR DESCRIPTION
## Program
General Contributor (no program affiliation)

## Description
The PR Stage Manager workflow (`.github/workflows/pr-stage-manage.yml`) fails on every fork PR that receives a review, showing a red `stage-manager` check even though the PR itself is fine.

The workflow runs on both `pull_request_target` and `pull_request_review`. The `pull_request_target` runs get a write `GITHUB_TOKEN` even for forks, but a `pull_request_review` submitted by an external fork contributor runs with a read-only token, regardless of the declared `issues: write` / `pull-requests: write` permissions.

The label helpers `addLabel` / `removeLabel` already wrap their calls in try/catch and only warn, so those degrade gracefully. The comment writes did not: with a read-only token, `github.rest.issues.createComment` (and `updateComment`) throws `Resource not accessible by integration`, and because the call was unhandled the whole job failed.

This change wraps both comment writes in try/catch that logs a warning instead of throwing, matching the existing label-helper pattern. The pipeline comment is cosmetic and is still created/updated by the `pull_request_target` runs that hold a write token, so no functionality is lost.

## Related Issue
Closes #2016

## Type of Change
- [x] Bug fix
- [x] CI / configuration

## How to Test
1. Open a PR from a fork and have someone submit a review, firing the `pull_request_review` trigger.
2. The `stage-manager` job completes successfully instead of failing with `Resource not accessible by integration`.
3. When the token lacks write access, a warning is logged and the job still passes; label/comment state is maintained by the `pull_request_target` runs.

## Screenshots (if applicable)
N/A (CI / workflow change)

## Checklist
- [x] I am contributing as an independent/general contributor
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools
