### PR TITLE
Chore: removed unused data-org-index & orgIndex field

### DIFF
--- a/src/js/recommendation-ui.js
+++ b/src/js/recommendation-ui.js
@@ -137,7 +137,6 @@ function buildCardHtml(rec, currentCompareList, currentBookmarkedSet) {
     return `
     <article class="group relative bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-zinc-100 dark:border-zinc-800 transition-all hover:shadow-xl hover:border-primary/20 animate-fade-up cursor-pointer flex flex-col ${inCompare ? 'ring-2 ring-primary/30' : ''}"
              data-org-name="${safeEscapeHtml(o.name)}"
-             data-org-index="${rec.orgIndex}"
              tabindex="-1">
       <div class="absolute top-0 right-0 bg-gradient-to-bl from-green-500 to-emerald-600 text-white px-3 py-1.5 rounded-bl-2xl rounded-tr-2xl font-bold text-xs shadow-sm flex items-center gap-1 z-10">
         <span class="material-symbols-outlined text-sm">target</span> ${rec.score}% Match

--- a/src/js/recommender.js
+++ b/src/js/recommender.js
@@ -168,7 +168,6 @@ function calculateScoreForOrg(org, index, userLanguages, userTopics, githubProfi
   }
 
   return {
-    orgIndex: index,
     org: org,
     score: cappedScore, 
     rawScore: finalRawScore,

--- a/tests/recommendation.test.js
+++ b/tests/recommendation.test.js
@@ -26,7 +26,6 @@ test('getRecommendations returns top 6 recommendations sorted by score', () => {
 
   // Each recommendation object must have required properties
   recommendations.forEach(rec => {
-    assert.ok('orgIndex' in rec);
     assert.ok('org' in rec);
     assert.ok('score' in rec);
     assert.ok('rawScore' in rec);


### PR DESCRIPTION
## 📝 Description

-  Removed `orgIndex` in `recommender.js`. Dead field as it is used only in `handleCardActivation` which now uses `data-org-name` instead.
- Removed 'data-org-index` from the `recommendation-ui.js`.
-  Updated `tests/recommendation.test.js` to drop the `assert.ok('orgIndex' in rec)` check since the field no longer exists.

## Testing
- `grep -rn "orgIndex"` shows no remaining references
<img width="1040" height="65" alt="Screenshot_2026-07-15-11-45-27 (Edit)" src="https://github.com/user-attachments/assets/9a26512c-70ae-49ab-aca7-79f677100685" />

- Full test suite passes
<img width="975" height="284" alt="image" src="https://github.com/user-attachments/assets/c6968364-be56-4774-9472-216700d62547" />
 
  
## 🔗 Related Issue
Closes #2013 

## 🚀 Program Classification
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [ ] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [x] 🧹 Refactor / cleanup

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

