### PR TITLE
feat: add Home button that will take user to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,9 +1209,10 @@ kbd:hover{
 
       <!-- Home button (links back to landing page) -->
       <a href="/" 
-         class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors"
+         class="hidden sm:inline-flex shrink-0 items-center gap-1 px-2 py-2 hover:bg-zinc-100/50 rounded-lg transition-colors text-zinc-600 hover:text-zinc-900"
          aria-label="Go to home page" title="Home">
-        <span class="material-symbols-outlined text-zinc-600">home</span>
+        <span class="material-symbols-outlined text-lg">home</span>
+        <span class="text-sm font-medium">Home</span>
       </a>
 
       <a href="#timeline" class="flex items-center gap-2" id="logoLink">

--- a/index.html
+++ b/index.html
@@ -1201,7 +1201,7 @@ kbd:hover{
 <!-- ═══════════════════ NAVBAR ═══════════════════ -->
 <header class="fixed top-0 w-full z-50 bg-white/80 glass shadow-sm">
   <div class="flex items-center justify-between px-4 sm:px-6 py-3 max-w-7xl mx-auto w-full">
-    <div class="flex items-center gap-3 sm:gap-4 xl:gap-8">
+    <div class="flex items-center gap-1.5 sm:gap-4 xl:gap-8">
       <!-- Hamburger menu button (mobile only) -->
       <button id="menuBtn" onclick="toggleMenu()" class="inline-flex lg:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-zinc-600">menu</span>
@@ -1209,10 +1209,10 @@ kbd:hover{
 
       <!-- Home button (links back to landing page) -->
       <a href="/" 
-         class="hidden sm:inline-flex shrink-0 items-center gap-1 px-2 py-2 hover:bg-zinc-100/50 rounded-lg transition-colors text-zinc-600 hover:text-zinc-900"
+         class="inline-flex shrink-0 items-center gap-1 px-1.5 sm:px-2 py-2 hover:bg-zinc-100/50 rounded-lg transition-colors text-zinc-600 hover:text-zinc-900"
          aria-label="Go to home page" title="Home">
         <span class="material-symbols-outlined text-lg">home</span>
-        <span class="text-sm font-medium">Home</span>
+        <span class="hidden xs:inline text-sm font-medium whitespace-nowrap">Home</span>
       </a>
 
       <a href="#timeline" class="flex items-center gap-2" id="logoLink">
@@ -1227,7 +1227,7 @@ kbd:hover{
       <nav class="hidden lg:flex items-center gap-4 xl:gap-6 text-sm font-medium">
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#orgs" data-section="orgs">Organizations</a>
-        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
+        <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors whitespace-nowrap" href="#ai-recommender" data-section="ai-recommender">AI Recommender</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#watchlist" data-section="watchlist">Watchlist</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#issues" data-section="issues">Issues</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#mentors" data-section="mentors">Mentors</a>

--- a/index.html
+++ b/index.html
@@ -1206,6 +1206,23 @@ kbd:hover{
       <button id="menuBtn" onclick="toggleMenu()" class="inline-flex lg:hidden shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors" aria-label="Open menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-zinc-600">menu</span>
       </button>
+
+      <!-- Home button (links back to landing page) -->
+      <a href="/" 
+         class="inline-flex shrink-0 items-center justify-center p-2 hover:bg-zinc-100/50 rounded-lg transition-colors"
+         aria-label="Go to home page" title="Home">
+        <span class="material-symbols-outlined text-zinc-600">home</span>
+      </a>
+
+      <a href="#timeline" class="flex items-center gap-2" id="logoLink">
+        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0">
+          <span class="text-white font-bold text-sm">G</span>
+        </div>
+        <span class="text-base sm:text-lg font-extrabold tracking-tight text-zinc-900 font-headline whitespace-nowrap">
+          <span class="hidden sm:inline">GSoC 2026 </span>
+          <span class="text-primary italic">Org Finder</span>
+        </span>
+      </a>
       
       <a href="#timeline" class="flex items-center gap-2" id="logoLink">
         <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0">

--- a/index.html
+++ b/index.html
@@ -1223,16 +1223,6 @@ kbd:hover{
           <span class="text-primary italic">Org Finder</span>
         </span>
       </a>
-      
-      <a href="#timeline" class="flex items-center gap-2" id="logoLink">
-        <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-primary to-primary-container flex items-center justify-center flex-shrink-0">
-          <span class="text-white font-bold text-sm">G</span>
-        </div>
-      <span class="text-base sm:text-lg font-extrabold tracking-tight text-zinc-900 font-headline whitespace-nowrap">
-        <span class="hidden sm:inline">GSoC 2026 </span>
-        <span class="text-primary italic">Org Finder</span>
-      </span>
-      </a>
       <nav class="hidden lg:flex items-center gap-4 xl:gap-6 text-sm font-medium">
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#timeline" data-section="timeline">Timeline</a>
         <a class="desktop-nav-link text-zinc-600 hover:text-zinc-900 transition-colors" href="#orgs" data-section="orgs">Organizations</a>


### PR DESCRIPTION
## 📝 Description
Adds a Home button to the /app dashboard header, allowing users to navigate back to the landing page (/) without using the browser's back button. Previously, there was no direct way to return to the marketing/landing page from within the app.

## Changes Made

- Added a new **Home** link (icon + label) to the left of the logo in the `/app` header, linking to `/`.
- Used the `home` Material Symbols icon, matching the existing icon style used elsewhere in the header (theme toggle, analytics, help).
- Added responsive behavior:
  - Icon is always visible on all screen sizes.
  - "Home" text label hides below the `xs` (480px) breakpoint to avoid crowding on very small phones.
- Fixed a nav-link wrapping bug: added `whitespace-nowrap` to the "AI Recommender" link so it no longer breaks onto two lines in the desktop nav.
- Reduced the gap between the hamburger menu, Home button, and logo on mobile (`gap-3` → `gap-1.5`) for a tighter, less crowded mobile header, while keeping the original spacing (`sm:gap-4`, `xl:gap-8`) on larger screens.
- Verified no duplicate `#logoLink` elements remain in the header (a duplicate had been introduced during an earlier edit and is now fixed).

## 🔗 Related Issue
Closes #2019 

## 🚀 Program Classification
<!-- Choose the program this contribution is for -->
- [x] GSSoC26

## 🔄 Type of Change
<!-- Check all that apply -->
- [x 🐛 Bug fix
- [x] ✨ New feature

## 📸 Screen recordings

### Desktop View:

https://github.com/user-attachments/assets/a6ea86ee-78aa-4883-814f-e5a868a3753f

### Mobile View:

https://github.com/user-attachments/assets/bcab35de-ab88-4718-9abd-281f10970af2

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

