### PR TITLE
fix(ci): remove empty step breaking program-classification-validator workflow

### DIFF
--- a/.github/workflows/program-classification-validator.yml
+++ b/.github/workflows/program-classification-validator.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-      # No checkout/setup-node needed for actions/github-script-only workflow
       - name: Validate classification
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
         env:


### PR DESCRIPTION
## Description

The `program-classification-validator` workflow has a `Checkout repository` step with no `uses` or `run`. GitHub Actions requires every step to have one, so it rejected the workflow as invalid (the "This run likely failed because of a workflow file issue" error) and every run failed before doing anything. The step was a no-op anyway; its own comment notes no checkout is needed for a github-script-only workflow, so I removed it. `Validate classification` is now the first step.

## Related Issue

No existing issue; this is a CI fix for the failing workflow.

## Program Classification

- [x] General Contribution

## Type of Change

- [x] Bug fix
- [x] CI / configuration

## How to Test

1. Run `actionlint .github/workflows/program-classification-validator.yml`.
2. Before this change it reports `step must run script with "run" section or run action with "uses" section` at the `Checkout repository` step and exits non-zero.
3. After removing the step it exits 0 with no errors.
4. Once merged, the workflow parses and runs on new pull requests instead of failing immediately.

## Checklist

- [x] My code follows the project's existing style
- [ ] I have tested my changes in a browser (not applicable; CI workflow change, validated with actionlint)
- [ ] I have linked the related issue above (no issue exists)
- [x] My PR title follows Conventional Commits format
- [x] I have not introduced any new dependencies or build tools
