### PR TITLE
fix(ci): skip mentor stats push when GITHUB_TOKEN is read-only on fork reviews

### DIFF
--- a/.github/workflows/mentor-review-tracker.yml
+++ b/.github/workflows/mentor-review-tracker.yml
@@ -54,6 +54,7 @@ jobs:
         run: node .github/scripts/update-mentor-stats.js
 
       - name: Commit stats when changed
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Description

Mentor Review Tracker runs on `pull_request_review`. For reviews on fork PRs, GitHub hands the workflow a read-only `GITHUB_TOKEN` no matter what the `permissions` block asks for, so the final `git push origin HEAD:main` in the "Commit stats when changed" step is denied with a 403 and the whole check fails:

```
remote: Permission to S3DFX-CYBER/GSoC-Org-Finder-.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

This is the same step as #2014 but a different cause. #2015 fixed the `git add -f` and the detached-ref checkout, so the commit and rebase now succeed; only the push is denied. Since most PRs come from forks, the tracker shows a red X on nearly every review.

This gates the commit-and-push step on the PR coming from the same repository, so it only runs when the token can actually write. Fork-triggered reviews skip the push instead of failing the run.

Fully persisting stats for fork-PR reviews needs a write-token context (a separate `workflow_run` job), which I left for maintainers to decide and described in the issue.

## Related Issue
Closes #2036

## Program Classification
- [x] General Contribution

## Type of Change
- [x] Bug fix
- [x] CI / configuration

## How to Test
1. Trigger the workflow with a review on a fork PR: the "Commit stats when changed" step is now skipped and the job succeeds instead of failing on the 403.
2. Trigger it with a review on a same-repo branch PR: the condition is true, so the step still commits and pushes the updated stats as before.
3. YAML validates (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/mentor-review-tracker.yml'))"`).

## Checklist
- [x] My change follows the project's existing style
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format
- [x] I have not introduced any new dependencies or build tools
- [x] Commit is DCO signed-off
