### PR TITLE
fix: prevented fixed FAB buttons from overlapping footer content on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1164,7 +1164,7 @@ kbd:hover{
       }
     }
 
-    @media (max-width: 639px) {
+    @media (max-width: 768px) {
       .premium-footer {
         padding-bottom: calc(
           var(--section-fab-bottom)
@@ -1182,6 +1182,12 @@ kbd:hover{
           - env(safe-area-inset-right)
           - 8px
         );
+      }
+    }
+
+    @media (min-width: 769px) {
+      .premium-footer {
+        padding-bottom: 1.5rem;
       }
     } 
 

--- a/index.html
+++ b/index.html
@@ -1163,6 +1163,27 @@ kbd:hover{
         border-radius: 999px;
       }
     }
+
+    @media (max-width: 768px) {
+      .premium-footer {
+        padding-bottom: calc(
+          var(--section-fab-bottom)
+          (var(--section-fab-size) + var(--section-fab-gap)) * 2
+          env(safe-area-inset-bottom)
+          16px
+        );
+      }
+
+      .premium-footer .footer-legal-row {
+        padding-right: calc(
+          var(--section-fab-right)
+          var(--section-fab-size)
+          env(safe-area-inset-right)
+          8px
+        );
+      }
+    } 
+
 @media (pointer: coarse) {
   .filter-chip.bg-orange-600:hover {
     background-color: #ea580c !important;

--- a/index.html
+++ b/index.html
@@ -1164,7 +1164,7 @@ kbd:hover{
       }
     }
 
-    @media (max-width: 768px) {
+    @media (max-width: 639px) {
       .premium-footer {
         padding-bottom: calc(
           var(--section-fab-bottom)
@@ -1173,7 +1173,7 @@ kbd:hover{
           + 16px
         );
       }
-    
+
       .footer-social-row {
         max-width: calc(
           100%

--- a/index.html
+++ b/index.html
@@ -1168,18 +1168,19 @@ kbd:hover{
       .premium-footer {
         padding-bottom: calc(
           var(--section-fab-bottom)
-          (var(--section-fab-size) + var(--section-fab-gap)) * 2
-          env(safe-area-inset-bottom)
-          16px
+          + (var(--section-fab-size) + var(--section-fab-gap)) * 2
+          + env(safe-area-inset-bottom)
+          + 16px
         );
       }
-
-      .premium-footer .footer-legal-row {
-        padding-right: calc(
-          var(--section-fab-right)
-          var(--section-fab-size)
-          env(safe-area-inset-right)
-          8px
+    
+      .footer-social-row {
+        max-width: calc(
+          100%
+          - var(--section-fab-right)
+          - var(--section-fab-size)
+          - env(safe-area-inset-right)
+          - 8px
         );
       }
     } 

--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -109,7 +109,7 @@
     </div>
 
     <!-- Social Links and Privacy link -->
-    <div class="flex items-center gap-4 flex-wrap justify-center footer-social-row">
+    <div class="flex items-center gap-3 sm:gap-4 flex-wrap justify-center footer-social-row">
       <a class="footer-link text-xs font-bold uppercase tracking-widest text-zinc-600 hover:text-primary dark:text-zinc-300 transition-colors mr-2"
         href="privacy.html">Privacy Policy</a>
       <a class="social-link github" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank"

--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -1,4 +1,4 @@
-<footer class="w-full premium-footer pb-32 sm:pb-6 pt-12 px-6 sm:px-8">
+<footer class="w-full premium-footer sm:pb-6 pt-12 px-6 sm:px-8">
   <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-10 mb-12">
     <!-- Branding Section -->
     <div class="lg:col-span-2 flex flex-col gap-4">

--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -1,4 +1,4 @@
-<footer class="w-full premium-footer pb-6 pt-12 px-6 sm:px-8">
+<footer class="w-full premium-footer pb-32 sm:pb-6 pt-12 px-6 sm:px-8">
   <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-10 mb-12">
     <!-- Branding Section -->
     <div class="lg:col-span-2 flex flex-col gap-4">
@@ -96,8 +96,9 @@
   </div>
 
   <!-- Bottom Divider and Legal Section -->
+  
   <div
-    class="max-w-7xl mx-auto pt-8 border-t border-zinc-200/50 dark:border-zinc-800/50 flex flex-col sm:flex-row justify-between items-center gap-6">
+    class="footer-legal-row max-w-7xl mx-auto pt-8 border-t border-zinc-200/50 dark:border-zinc-800/50 flex flex-col sm:flex-row justify-between items-center gap-6">
     <div class="flex flex-col gap-1.5 text-center sm:text-left">
       <p class="text-xs font-bold text-zinc-500 dark:text-zinc-400">
         © 2026 S3DFX-CYBER · Built for the Open Source Community

--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -1,4 +1,4 @@
-<footer class="w-full premium-footer sm:pb-6 pt-12 px-6 sm:px-8">
+<footer class="w-full premium-footer pt-12 px-6 sm:px-8">
   <div class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-10 mb-12">
     <!-- Branding Section -->
     <div class="lg:col-span-2 flex flex-col gap-4">

--- a/src/components/footer.html
+++ b/src/components/footer.html
@@ -109,7 +109,7 @@
     </div>
 
     <!-- Social Links and Privacy link -->
-    <div class="flex items-center gap-4 flex-wrap justify-center">
+    <div class="flex items-center gap-4 flex-wrap justify-center footer-social-row">
       <a class="footer-link text-xs font-bold uppercase tracking-widest text-zinc-600 hover:text-primary dark:text-zinc-300 transition-colors mr-2"
         href="privacy.html">Privacy Policy</a>
       <a class="social-link github" href="https://github.com/S3DFX-CYBER/GSoC-Org-Finder-" target="_blank"


### PR DESCRIPTION
## 📝 Description

**Problem:**
On mobile viewports (`<768px`) the two fixed position scroll buttons overlap footer content.

**Solution:**
The footer width was not reduced as the FABs are `position: fixed` relative to the viewport not the footer. Changing the footer width would therefore not prevent the overlap. Instead I added Vertical padding to keep the footer content above the fixed FABs & Horizontal padding to keep the text & social icons clear of the FABs.

This prevents the footer content from being obscured while keeping the existing layout intact.

**Changes made:**
- Added bottom padding to keep footer content above the fixed buttons.
- Added right padding to prevent the buttons from overlapping legal text & social icons.
- Desktop layout (`>768px`) is completely unaffected.

**Files changed:** `index.html`, `src/components/footer.html`

## 🔗 Related Issue
Closes #1999 

## 🚀 Program Classification
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 📸 Screenshots
<p align="center">
<img width="45%" height="855" alt="image" src="https://github.com/user-attachments/assets/85751223-3dfd-4307-b76d-85297e07c00c" />
<img width="45%" height="858" alt="Screenshot_2026-07-26-18-55-33" src="https://github.com/user-attachments/assets/baa28f23-0060-4652-bdb4-22332b8e2a5d" />
</p>


## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

