### PR TITLE
fix: replaced overflowing mobile comparison table with 1-on-1 tabbed view

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -706,8 +706,7 @@
         </p>
       </div>
 
-      <!-- Comparison Table -->
-      <div class="max-w-4xl mx-auto mb-16 overflow-x-auto">
+      <div class="max-w-4xl mx-auto mb-16 overflow-x-auto>
         <table class="w-full text-sm border-collapse">
           <thead>
             <tr>
@@ -734,6 +733,42 @@
           <tbody id="comparisonRows" class="divide-y divide-zinc-100 dark:divide-zinc-800/60">
           </tbody>
         </table>
+      </div>
+      
+
+      <div class="md:hidden max-w-md mx-auto mb-16">
+        <table class="w-full text-sm border-collapse table-fixed">
+          <thead>
+            <tr>
+              <th class="text-left pb-4 pr-3 text-zinc-400 dark:text-zinc-500 font-semibold text-xs uppercase tracking-widest w-1/2">
+              Feature
+              </th>
+              <th class="pb-4 px-2 text-center w-1/4">
+                <div class="inline-flex flex-col items-center gap-1">
+                  <span class="text-sm font-extrabold text-primary font-headline">FindMyGSoC</span>
+                  <span class="text-[9px] uppercase tracking-widest text-orange-400 font-bold bg-orange-50 dark:bg-orange-950/30 px-2 py-0.5 rounded-full">This tool</span>
+                </div>
+              </th>
+              <th class="pb-4 px-2 text-center text-zinc-400 dark:text-zinc-500 font-semibold text-xs w-1/4">
+                <span id="mobileCompetitorLabel">GSoC Portal</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody id="comparisonRowsMobile" class="divide-y divide-zinc-100 dark:divide-zinc-800/60">
+          </tbody>
+        </table>
+
+        <div id="competitorTabs" role="tablist" aria-label="Choose a competitor to compare against" class="mt-5 flex flex-wrap justify-center gap-1 p-1 rounded-full bg-zinc-100 dark:bg-zinc-800/60 border border-zinc-200/70 dark:border-zinc-700/60">
+          <button type="button" role="tab" aria-selected="true" data-competitor="gsoc" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 border border-primary shadow-sm">
+          GSoC Portal
+          </button>
+          <button type="button" role="tab" aria-selected="false" data-competitor="god" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
+          Org Directory
+          </button>
+          <button type="button" role="tab" aria-selected="false" data-competitor="gh" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
+          GitHub / Manual
+          </button>
+        </div>
       </div>
 
       <!-- Advantage highlight cards -->

--- a/landing.html
+++ b/landing.html
@@ -706,7 +706,7 @@
         </p>
       </div>
 
-      <div class="max-w-4xl mx-auto mb-16 overflow-x-auto>
+      <div class="hidden md:block max-w-4xl mx-auto mb-16 overflow-x-auto">
         <table class="w-full text-sm border-collapse">
           <thead>
             <tr>
@@ -735,7 +735,7 @@
         </table>
       </div>
       
-
+      <!-- mobile only 1-on-1 tabbed comparison -->
       <div class="md:hidden max-w-md mx-auto mb-16">
         <table class="w-full text-sm border-collapse table-fixed">
           <thead>

--- a/landing.html
+++ b/landing.html
@@ -765,7 +765,7 @@
           GSoC Portal
           </button>
           <button type="button" role="tab" id="tab-god" aria-selected="false" aria-controls="comparisonTabpanel" tabindex="-1" data-competitor="god" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
-          Org Directory
+          gsocorganizations.dev
           </button>
           <button type="button" role="tab" id="tab-gh" aria-selected="false" aria-controls="comparisonTabpanel" tabindex="-1" data-competitor="gh" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
           GitHub / Manual

--- a/landing.html
+++ b/landing.html
@@ -737,39 +737,41 @@
       
       <!-- mobile only 1-on-1 tabbed comparison -->
       <div class="md:hidden max-w-md mx-auto mb-16">
-        <table class="w-full text-sm border-collapse table-fixed">
-          <thead>
-            <tr>
-              <th class="text-left pb-4 pr-3 text-zinc-400 dark:text-zinc-500 font-semibold text-xs uppercase tracking-widest w-1/2">
-              Feature
-              </th>
-              <th class="pb-4 px-2 text-center w-1/4">
-                <div class="inline-flex flex-col items-center gap-1">
-                  <span class="text-sm font-extrabold text-primary font-headline">FindMyGSoC</span>
-                  <span class="text-[9px] uppercase tracking-widest text-orange-400 font-bold bg-orange-50 dark:bg-orange-950/30 px-2 py-0.5 rounded-full">This tool</span>
-                </div>
-              </th>
-              <th class="pb-4 px-2 text-center text-zinc-400 dark:text-zinc-500 font-semibold text-xs w-1/4">
-                <span id="mobileCompetitorLabel">GSoC Portal</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody id="comparisonRowsMobile" class="divide-y divide-zinc-100 dark:divide-zinc-800/60">
-          </tbody>
-        </table>
+        <div id="comparisonTabpanel" role="tabpanel" aria-labelledby="tab-gsoc" tabindex="0">
+          <table class="w-full text-sm border-collapse table-fixed">
+            <thead>
+              <tr>
+                <th class="text-left pb-4 pr-3 text-zinc-400 dark:text-zinc-500 font-semibold text-xs uppercase tracking-widest w-1/2">
+                  Feature
+                </th>
+                <th class="pb-4 px-2 text-center w-1/4">
+                  <div class="inline-flex flex-col items-center gap-1">
+                    <span class="text-sm font-extrabold text-primary font-headline">FindMyGSoC</span>
+                    <span class="text-[9px] uppercase tracking-widest text-orange-400 font-bold bg-orange-50 dark:bg-orange-950/30 px-2 py-0.5 rounded-full">This tool</span>
+                  </div>
+                </th>
+                <th class="pb-4 px-2 text-center text-zinc-400 dark:text-zinc-500 font-semibold text-xs w-1/4">
+                  <span id="mobileCompetitorLabel">GSoC Portal</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="comparisonRowsMobile" class="divide-y divide-zinc-100 dark:divide-zinc-800/60">
+            </tbody>
+          </table>
+        </div>
 
         <div id="competitorTabs" role="tablist" aria-label="Choose a competitor to compare against" class="mt-5 flex flex-wrap justify-center gap-1 p-1 rounded-full bg-zinc-100 dark:bg-zinc-800/60 border border-zinc-200/70 dark:border-zinc-700/60">
-          <button type="button" role="tab" aria-selected="true" data-competitor="gsoc" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 border border-primary shadow-sm">
+          <button type="button" role="tab" id="tab-gsoc" aria-selected="true" aria-controls="comparisonTabpanel" tabindex="0" data-competitor="gsoc" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 border border-primary shadow-sm">
           GSoC Portal
           </button>
-          <button type="button" role="tab" aria-selected="false" data-competitor="god" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
+          <button type="button" role="tab" id="tab-god" aria-selected="false" aria-controls="comparisonTabpanel" tabindex="-1" data-competitor="god" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
           Org Directory
           </button>
-          <button type="button" role="tab" aria-selected="false" data-competitor="gh" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
+          <button type="button" role="tab" id="tab-gh" aria-selected="false" aria-controls="comparisonTabpanel" tabindex="-1" data-competitor="gh" class="compare-tab-btn px-4 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap transition-colors border border-transparent text-zinc-500 dark:text-zinc-400">
           GitHub / Manual
           </button>
         </div>
-      </div>
+      </div> 
 
       <!-- Advantage highlight cards -->
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">

--- a/src/js/landing.js
+++ b/src/js/landing.js
@@ -73,6 +73,7 @@ const COMPARISON_DATA = [
   { feature: 'No login or signup needed',  fmg: 'primary',   gsoc: 'secondary', god: 'secondary', gh: 'secondary' },
 ];
 
+/** Competitors data (for mobile viewport 1-on-1 tabbed comparision)**/
 const COMPETITORS = [
   { key: 'gsoc', label: 'GSoC Portal', href: null },
   { key: 'god', label: 'gsocorganizations.dev', href: 'https://www.gsocorganizations.dev/' },

--- a/src/js/landing.js
+++ b/src/js/landing.js
@@ -214,14 +214,22 @@ function setActiveCompetitorTab(key) {
   document.querySelectorAll('.compare-tab-btn').forEach((btn) => {
     const isActive = btn.dataset.competitor === key;
     btn.setAttribute('aria-selected', String(isActive));
+    btn.setAttribute('tabindex', isActive ? '0' : '-1');
     btn.classList.remove(...TAB_ACTIVE_CLASSES, ...TAB_INACTIVE_CLASSES);
     btn.classList.add('border', ...(isActive ? TAB_ACTIVE_CLASSES : TAB_INACTIVE_CLASSES));
+
+    if (isActive) {
+      const panel = document.getElementById('comparisonTabpanel');
+      if (panel) { panel.setAttribute('aria-labelledby', btn.id); }
+    }
   });
 }
 
 function initComparisonTabs() {
   const container = document.getElementById('competitorTabs');
   if (!container) { return; }
+
+  const tabs = Array.from(container.querySelectorAll('.compare-tab-btn'));
 
   const activate = (key) => {
     const competitor = COMPETITORS.find((c) => c.key === key);
@@ -235,6 +243,28 @@ function initComparisonTabs() {
     const btn = e.target.closest('.compare-tab-btn');
     if (!btn) { return; }
     activate(btn.dataset.competitor);
+  });
+
+  container.addEventListener('keydown', (e) => {
+    const currentIndex = tabs.findIndex((t) => t.getAttribute('aria-selected') === 'true');
+
+    let targetIndex = null;
+    if (e.key === 'ArrowRight') {
+      targetIndex = (currentIndex + 1) % tabs.length;
+    } else if (e.key === 'ArrowLeft') {
+      targetIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+    } else if (e.key === 'Home') {
+      targetIndex = 0;
+    } else if (e.key === 'End') {
+      targetIndex = tabs.length - 1;
+    } else {
+      return;
+    }
+
+    e.preventDefault();
+    const targetTab = tabs[targetIndex];
+    targetTab.focus();
+    activate(targetTab.dataset.competitor);
   });
 
   activate(COMPETITORS[0].key);

--- a/src/js/landing.js
+++ b/src/js/landing.js
@@ -73,6 +73,12 @@ const COMPARISON_DATA = [
   { feature: 'No login or signup needed',  fmg: 'primary',   gsoc: 'secondary', god: 'secondary', gh: 'secondary' },
 ];
 
+const COMPETITORS = [
+  { key: 'gsoc', label: 'GSoC Portal', href: null },
+  { key: 'god', label: 'gsocorganizations.dev', href: 'https://www.gsocorganizations.dev/' },
+  { key: 'gh', label: 'GitHub / Manual', href: null },
+];
+
 // ── FAQ Data ──────────────────────────────────────────────────────────────────
 
 /** Single source of truth — eliminates duplicated accordion blocks in markup */
@@ -152,6 +158,85 @@ function renderComparisonRows() {
   }
 
   tbody.appendChild(fragment);
+}
+
+function renderMobileComparisonRows(competitorKey) {
+  const tbody = document.getElementById('comparisonRowsMobile');
+  if (!tbody) { return; }
+
+  tbody.textContent = '';
+  const fragment = document.createDocumentFragment();
+
+  for (const row of COMPARISON_DATA) {
+    const tr = document.createElement('tr');
+
+    const featureTd = document.createElement('td');
+    featureTd.className = 'py-3.5 pr-3 text-zinc-700 dark:text-zinc-300 font-medium';
+    featureTd.textContent = row.feature;
+    tr.appendChild(featureTd);
+
+    tr.appendChild(createComparisonCell(row.fmg));
+    tr.appendChild(createComparisonCell(row[competitorKey]));
+
+    fragment.appendChild(tr);
+  }
+
+  tbody.appendChild(fragment);
+}
+
+function updateMobileCompetitorHeader(competitor) {
+  const labelEl = document.getElementById('mobileCompetitorLabel');
+  if (!labelEl) { return; }
+
+  labelEl.textContent = '';
+
+  if (competitor.href) {
+    const link = document.createElement('a');
+    link.href = competitor.href;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.className = 'hover:text-primary transition-colors underline decoration-dotted';
+    link.textContent = competitor.label;
+    labelEl.appendChild(link);
+  } else {
+    labelEl.textContent = competitor.label;
+  }
+}
+
+const TAB_ACTIVE_CLASSES = [
+  'bg-white', 'dark:bg-zinc-900', 'text-zinc-900', 'dark:text-zinc-50',
+  'border-primary', 'shadow-sm',
+];
+const TAB_INACTIVE_CLASSES = ['border-transparent', 'text-zinc-500', 'dark:text-zinc-400'];
+
+function setActiveCompetitorTab(key) {
+  document.querySelectorAll('.compare-tab-btn').forEach((btn) => {
+    const isActive = btn.dataset.competitor === key;
+    btn.setAttribute('aria-selected', String(isActive));
+    btn.classList.remove(...TAB_ACTIVE_CLASSES, ...TAB_INACTIVE_CLASSES);
+    btn.classList.add('border', ...(isActive ? TAB_ACTIVE_CLASSES : TAB_INACTIVE_CLASSES));
+  });
+}
+
+function initComparisonTabs() {
+  const container = document.getElementById('competitorTabs');
+  if (!container) { return; }
+
+  const activate = (key) => {
+    const competitor = COMPETITORS.find((c) => c.key === key);
+    if (!competitor) { return; }
+    renderMobileComparisonRows(key);
+    updateMobileCompetitorHeader(competitor);
+    setActiveCompetitorTab(key);
+  };
+
+  container.addEventListener('click', (e) => {
+    const btn = e.target.closest('.compare-tab-btn');
+    if (!btn) { return; }
+    activate(btn.dataset.competitor);
+  });
+
+  activate(COMPETITORS[0].key);
 }
 
 /**
@@ -385,6 +470,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Render data-driven sections
   renderComparisonRows();
+  initComparisonTabs();
   renderFaqList();
 
   // FAQ accordion — event delegation on the dynamically rendered list


### PR DESCRIPTION
## 📝 Description
**Problem:** The "Why FindMyGSoC Over Others?" comparison table wrapped in `overflow-x-auto`. On mobile viewports the browser enables horizontal scrolling instead of reflowing the content making the table harder to read & compare.
This PR improves the comparison table for mobile devices.

**Solution:**
- The existing 5 column table is now shown only on tablet screens & larger (`md:≥768px`) keeping the current desktop layout unchanged.
- Below that breakpoint (mobile viewport) a 1-on-1 tabbed comparision table renders instead: 
`Feature | FindMyGSoC | <selected competitor>`
`FindMyGSoC` is always visible & users can switch between competitors using a pill shaped tab menu (GSoC Portal, gsocorganizations.dev or GitHub & Manual) for an easy 1-on-1 comparison without horizontal scrolling.

No new dependencies. Reuses the existing `COMPARISON_DATA` array & `createComparisonCell()` helper.

## 🔗 Related Issue
Closes #2032 

## 🚀 Program Classification
- [x] GSSoC26
- [ ] NSoC26
- [ ] General Contribution

## 🔄 Type of Change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [ ] ♿ Accessibility improvement
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

## 📸 Screenshots
<img width="1919" height="1079" alt="Screenshot_2026-07-31-12-49-23 1(Edit)" src="https://github.com/user-attachments/assets/39adbdb1-7270-4ef2-958f-467d9d0aaa40" />
<img width="1919" height="1079" alt="Screenshot_2026-07-31-12-48-44 (Edit)" src="https://github.com/user-attachments/assets/37c786c1-3d91-4864-a230-f88464b5d547" />

## ✅ Checklist
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format (e.g. `feat: add scroll button`)
- [x] I have not introduced any new dependencies or build tools

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

