### PR TITLE
feat: Add scroll position memory after page refresh (#2044)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2446,6 +2446,20 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   })();
 
+  // Restore scroll position from sessionStorage
+  (function restoreScrollPosition() {
+    const savedPos = sessionStorage.getItem('scrollPos');
+    if (savedPos) {
+      const pos = parseInt(savedPos, 10);
+      if (!isNaN(pos)) {
+        requestAnimationFrame(() => {
+          window.scrollTo(0, pos);
+        });
+      }
+      sessionStorage.removeItem('scrollPos');
+    }
+  })();
+
   updateCountdown();
   const countdownTimer = setInterval(updateCountdown, 60000);
   if (typeof countdownTimer.unref === 'function') countdownTimer.unref();
@@ -2607,6 +2621,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+});
+
+// ══════════════════════════════════════════════
+// SCROLL POSITION MEMORY — save on page unload
+// ══════════════════════════════════════════════
+window.addEventListener('beforeunload', () => {
+  sessionStorage.setItem('scrollPos', String(window.scrollY));
 });
 
 // ══════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Restore the user's previous scroll position when the page is accidentally refreshed.

## Changes

- Save `window.scrollY` to `sessionStorage` on `beforeunload`
- Restore scroll position on `DOMContentLoaded` with `requestAnimationFrame` for smooth rendering
- Clean up the stored value after restoration to prevent stale positions

## Implementation Details

- Uses `sessionStorage` (not `localStorage`) so the position is only remembered within the current tab session
- Uses `requestAnimationFrame` to wait for the DOM to settle before scrolling
- Cleans up the stored value after restoration to avoid re-scrolling on subsequent normal navigations

## Acceptance Criteria

- [x] Scroll position stored before refresh
- [x] Position restored after reload
- [x] No noticeable delay
- [x] Works across supported browsers

Closes #2044

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/S3DFX-CYBER/GSoC-Org-Finder-/pull/2051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

