### PR TITLE
fix: verify openSUSE Project GSoC 2026 mentor contacts (closes #379)

### DIFF
--- a/data/mentors.json
+++ b/data/mentors.json
@@ -3760,13 +3760,61 @@
   },
   "openSUSE Project": {
     "org": "openSUSE Project",
-    "ideasUrl": "https://en.opensuse.org/openSUSE:GSOC",
-    "channels": [],
-    "mentors": [],
-    "mailingLists": [],
-    "tip": "",
-    "status": "fetch-failed",
-    "lastFetched": "2026-05-09T16:09:12.548Z"
+    "ideasUrl": "https://github.com/openSUSE/mentoring/issues",
+    "channels": [ {
+      "type": "Matrix",
+      "url": "https://chat.opensuse.org",
+      "label": "openSUSE Matrix Chat"
+    }, {
+      "type": "Discord",
+      "url": "https://discord.com/invite/opensuse",
+      "label": "openSUSE Discord"
+    }, {
+      "type": "Mailing list",
+      "url": "https://lists.opensuse.org/archives/list/project@lists.opensuse.org/",
+      "label": "openSUSE Project Mailing List"
+    }, {
+      "type": "Mailing list",
+      "url": "https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/",
+      "label": "openSUSE Factory Mailing List"
+    }],
+    "mentors": [ {
+      "name": "Cédric Bosdonnat",
+      "github": "cbosdo",
+      "githubUrl": "https://github.com/cbosdo"
+    }, {
+      "name": "Óscar Barrios",
+      "github": "srbarrios",
+      "githubUrl": "https://github.com/srbarrios"
+    }, {
+      "name": "Jordi Massaguer Pla",
+      "github": "jordimassaguerpla",
+      "githubUrl": "https://github.com/jordimassaguerpla"
+    }, {
+      "name": "Ondřej Holeček",
+      "github": "aaannz",
+      "githubUrl": "https://github.com/aaannz"
+    }, {
+      "name": "Abid Mehmood",
+      "github": "admd",
+      "githubUrl": "https://github.com/admd"
+    }, {
+      "name": "Marvin Friedrich",
+      "github": "MarvinFriedrich",
+      "githubUrl": "https://github.com/MarvinFriedrich"
+    }],
+    "mailingLists": [ {
+      "type": "Mailing list",
+      "url": "https://lists.opensuse.org/archives/list/project@lists.opensuse.org/",
+      "label": "openSUSE Project Mailing List"
+    }, {
+      "type": "Mailing list",
+      "url": "https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/",
+      "label": "openSUSE Factory Mailing List"
+    }],
+    "tip": "openSUSE mentors post GSoC project ideas as issues in the openSUSE/mentoring repo (labeled GSoC). Comment on the issue to reach the mentor directly. GSoC admin: Dan Demaio (ddemaio).",
+    "status": "ok",
+    "lastFetched": "2026-08-16T12:47:08.000Z"
   },
   "OpenVINO Toolkit": {
     "org": "OpenVINO Toolkit",


### PR DESCRIPTION
## Description

Verified and updated mentor/contact information for the **openSUSE Project** using official sources (Google Summer of Code 2026 organization page and the openSUSE/mentoring repository).

### Changes Made

- Updated the ideas URL from the stale wiki redirect (`https://en.opensuse.org/openSUSE:GSOC`, which only redirects to a generic portal page) to the official ideas list: **https://github.com/openSUSE/mentoring/issues** (mentors post GSoC ideas there as issues labeled `GSoC`, assigned to themselves)
- Added verified communication channels (all taken from the [Google Summer of Code 2026 openSUSE org page](https://summerofcode.withgoogle.com/programs/2026/organizations/opensuse-project)):
  - Matrix chat: https://chat.opensuse.org
  - Discord: https://discord.com/invite/opensuse
  - Mailing lists: `project@lists.opensuse.org` and `factory@lists.opensuse.org`
- Added **6 publicly verifiable 2026 GSoC mentors** — each handle confirmed via the GitHub API against the mentors of openSUSE's accepted GSoC 2026 projects:

| Mentor | GitHub |
|---|---|
| Cédric Bosdonnat | cbosdo |
| Óscar Barrios | srbarrios |
| Jordi Massaguer Pla | jordimassaguerpla |
| Ondřej Holeček | aaannz |
| Abid Mehmood | admd |
| Marvin Friedrich | MarvinFriedrich |

- Left out the remaining 2026 mentors (Pablo Gomez Oliva, Welder, Eugen Maksymenko, Doug, Daniel García Moreno, Michele Bussolotto) because no publicly verifiable GitHub handles were available from official sources
- Added a tip documenting how contributors can reach mentors (comment on the issue in openSUSE/mentoring)
- Changed status from `fetch-failed` to `ok`

## Program

program: gssoc

## Related Issue

Closes #379

## Type of Change

- [x] Data research / correction

## Checklist

- [x] Verified information from official sources (GSoC 2026 org page, openSUSE/mentoring repo)
- [x] Verified all mentor GitHub handles via the GitHub API
- [x] Maintained existing schema structure
- [x] Verified all updated links
- [x] Avoided adding unverified mentor handles